### PR TITLE
Mark default index in list_indices output

### DIFF
--- a/tests/mcp_server/list_indices.test.ts
+++ b/tests/mcp_server/list_indices.test.ts
@@ -2,54 +2,71 @@ import { listIndices } from '../../src/mcp_server/tools/list_indices';
 import { client } from '../../src/utils/elasticsearch';
 import { TextContent } from '@modelcontextprotocol/sdk/types';
 
-jest.mock('../../src/utils/elasticsearch');
+jest.mock('../../src/utils/elasticsearch', () => ({
+  client: {
+    indices: {
+      getAlias: jest.fn(),
+    },
+    search: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/config', () => ({
+  elasticsearchConfig: {
+    index: 'kibana-code-search-2.0', // Default index name for tests
+  },
+}));
+import { elasticsearchConfig } from '../../src/config';
 
 const mockClient = client as jest.Mocked<typeof client>;
-mockClient.indices = { getAlias: jest.fn() } as unknown;
-mockClient.search = jest.fn();
 
 describe('listIndices', () => {
-  it('should return a formatted string of index statistics', async () => {
+  beforeEach(() => {
+    (mockClient.indices.getAlias as jest.Mock).mockClear();
+    (mockClient.search as jest.Mock).mockClear();
+  });
+
+  it('should mark default when ELASTICSEARCH_INDEX matches the index name', async () => {
+    (elasticsearchConfig.index as any) = 'kibana-code-search-2.0';
     (mockClient.indices.getAlias as jest.Mock).mockResolvedValue({
       'kibana-code-search-2.0': { aliases: { 'kibana-repo': {} } },
       'grafana-code-search': { aliases: { 'grafana-repo': {} } },
     });
     (mockClient.search as jest.Mock).mockResolvedValue({
       aggregations: {
-        filesIndexed: { value: 73843 },
-        NumberOfSymbols: { total: { value: 226763 } },
-        Languages: {
-          buckets: [
-            { key: 'typescript', numberOfFiles: { value: 63452 } },
-            { key: 'javascript', numberOfFiles: { value: 3486 } },
-          ],
-        },
-        Types: {
-          buckets: [
-            { key: 'code', numberOfFiles: { value: 1757618 } },
-            { key: 'doc', numberOfFiles: { value: 68943 } },
-          ],
-        },
+        filesIndexed: { value: 100 },
+        NumberOfSymbols: { total: { value: 200 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
       },
     });
 
     const result = await listIndices();
-    const expected = `Index: kibana-repo
-- Files: 73,843 total
-- Symbols: 226,763 total
-- Languages: typescript (63.5K files), javascript (3.5K files)
-- Content: code (1.8M files), doc (68.9K files)
----
-Index: grafana-repo
-- Files: 73,843 total
-- Symbols: 226,763 total
-- Languages: typescript (63.5K files), javascript (3.5K files)
-- Content: code (1.8M files), doc (68.9K files)`;
+    const output = (result.content[0] as TextContent).text;
 
-    expect((result.content[0] as TextContent).text.trim()).toEqual(expected.trim());
-    expect(mockClient.indices.getAlias).toHaveBeenCalledWith({
-      name: '*-repo',
+    expect(output).toContain('Index: kibana-repo (Default)');
+    expect(output).not.toContain('Index: grafana-repo (Default)');
+  });
+
+  it('should mark default when ELASTICSEARCH_INDEX matches the alias name', async () => {
+    (elasticsearchConfig.index as any) = 'grafana-repo';
+    (mockClient.indices.getAlias as jest.Mock).mockResolvedValue({
+      'kibana-code-search-2.0': { aliases: { 'kibana-repo': {} } },
+      'grafana-code-search': { aliases: { 'grafana-repo': {} } },
     });
-    expect(mockClient.search).toHaveBeenCalledTimes(2);
+    (mockClient.search as jest.Mock).mockResolvedValue({
+      aggregations: {
+        filesIndexed: { value: 100 },
+        NumberOfSymbols: { total: { value: 200 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      },
+    });
+
+    const result = await listIndices();
+    const output = (result.content[0] as TextContent).text;
+
+    expect(output).not.toContain('Index: kibana-repo (Default)');
+    expect(output).toContain('Index: grafana-repo (Default)');
   });
 });


### PR DESCRIPTION
- Updated the `list_indices` tool to mark the default Elasticsearch index.
- The default index is now identified by comparing the `ELASTICSEARCH_INDEX` environment variable against both the index name and the alias.
- Updated tests to cover the new logic.

Prompts:

- "When the configured index matches the index for the alais, which value are you using?"
- "That is not correct, I want to match it against the top level key (which is the index name) of the object returned in the `getAlias()` function call. I would also like to match it against the alias exactly as well."

🤖 This commit was assisted by Gemini CLI