### PR TITLE
Refactor MCP server tools and improve documentation

### DIFF
--- a/src/mcp_server/server.ts
+++ b/src/mcp_server/server.ts
@@ -40,8 +40,9 @@ export class McpServer {
 
   private registerTools() {
     const semanticCodeSearchDescription = fs.readFileSync(path.join(__dirname, 'tools/semantic_code_search.md'), 'utf-8');
-    const listSymbolsByQueryDescription = fs.readFileSync(path.join(__dirname, 'tools/list_symbols_by_query.md'), 'utf-8');
+    // const listSymbolsByQueryDescription = fs.readFileSync(path.join(__dirname, 'tools/list_symbols_by_query.md'), 'utf-8');
     const symbolAnalysisDescription = fs.readFileSync(path.join(__dirname, 'tools/symbol_analysis.md'), 'utf-8');
+    const mapSymbolsByQueryDescription = fs.readFileSync(path.join(__dirname, 'tools/map_symbols_by_query.md'), 'utf-8');
 
     this.server.registerTool(
       'semantic_code_search',
@@ -52,10 +53,19 @@ export class McpServer {
       semanticCodeSearch
     );
 
+    // this.server.registerTool(
+    //   'list_symbols_by_query',
+    //   {
+    //     description: listSymbolsByQueryDescription,
+    //     inputSchema: listSymbolsByQuerySchema.shape,
+    //   },
+    //   listSymbolsByQuery
+    // );
+
     this.server.registerTool(
-      'list_symbols_by_query',
+      'map_symbols_by_query',
       {
-        description: listSymbolsByQueryDescription,
+        description: mapSymbolsByQueryDescription,
         inputSchema: listSymbolsByQuerySchema.shape,
       },
       listSymbolsByQuery

--- a/src/mcp_server/tools/map_symbols_by_query.md
+++ b/src/mcp_server/tools/map_symbols_by_query.md
@@ -1,0 +1,72 @@
+Query for a structured map of files containing specific symbols, grouped by file path.
+
+## Use Cases
+- **Post-Discovery Analysis**: After `symbol_analysis` reveals related symbols, use this tool with actual symbol names to see which files contain them
+- **Architecture Overview**: Get a file-by-file breakdown showing symbol counts (more symbols = more relevant)
+- **Finding Implementations**: Locate files that use multiple related symbols together
+- **Code Organization**: See how symbols are distributed across the codebase
+
+## When to Use
+- You have specific symbol names from `symbol_analysis` or `semantic_code_search`
+- You want to see which files are most relevant (contains most related symbols)
+- You need a structured view before diving into full file contents
+- You're mapping the relationship between multiple symbols
+
+## When NOT to Use
+- You don't know any symbol names yet (use `semantic_code_search` first)
+- You need the full file content (use `read_file_from_chunks`)
+- You want complete usage information for a single symbol (use `symbol_analysis`)
+
+## Workflow Position
+Typically the **third step** in investigation:
+1. `semantic_code_search` → discover symbols
+2. `symbol_analysis` → understand one key symbol's relationships
+3. **`map_symbols_by_query`** → see which files combine related symbols
+4. `read_file_from_chunks` → read the most relevant files
+
+## Parameters
+- `kql`: The KQL query string using **actual symbol names** (not generic terms)
+- `index`: (Optional) Specify only when searching across multiple indices. Omit to use the default index.
+
+## Example Workflow
+```json
+// After symbol_analysis on "onFilter" revealed: LensPublicCallbacks, PreventableEvent
+{ "kql": "\"onFilter\" and (LensPublicCallbacks or PreventableEvent)" }
+```
+
+## Output Format
+Returns a JSON object where:
+- **Keys**: File paths
+- **Values**:
+  - `symbols`: Grouped by kind (function.call, variable.name, etc.) with line numbers
+  - `imports`: Module imports with their symbols
+
+Files with **more symbol matches** are typically more relevant to your investigation.
+
+## Output Example
+```json
+{
+  "src/path/to/file.ts": {
+    "symbols": {
+      "function.call": [
+        { "name": "onFilter", "line": 42 }
+      ],
+      "variable.name": [
+        { "name": "eventHandler", "line": 35 }
+      ]
+    },
+    "imports": {
+      "module": [
+        {
+          "path": "@kbn/types",
+          "symbols": ["LensPublicCallbacks"]
+        }
+      ]
+    }
+  }
+}
+```
+
+**Note**: Symbols are grouped by type (function.call, variable.name, etc.) rather than a flat array.
+
+**Note**: The `index` parameter is optional. Only specify it when you need to search a specific index different from the default.

--- a/src/mcp_server/tools/read_file.ts
+++ b/src/mcp_server/tools/read_file.ts
@@ -106,7 +106,7 @@ export async function readFile({ filePaths, index }: z.infer<typeof readFileSche
     const chunks = chunksByFile.get(filePath);
 
     if (!chunks || chunks.length === 0) {
-      reconstructedFiles[filePath] = '// File not found in index';
+      reconstructedFiles[filePath] = '// File not found in index... try a relative path.';
       continue;
     }
 

--- a/src/mcp_server/tools/symbol_analysis.md
+++ b/src/mcp_server/tools/symbol_analysis.md
@@ -11,7 +11,7 @@ Precision tool for step 2 of "chain of investigation" - analyze specific symbols
 
 ## Parameters
 - `symbolName`: The name of the symbol to analyze.
-- `index`: The Elasticsearch index to search (optional).
+- `index`: (Optional) Specify only when searching across multiple indices. Omit to use the default index.
 
 ## Returns
 Comprehensive cross-referenced report showing:


### PR DESCRIPTION
- Rename `list_symbols_by_query` to `map_symbols_by_query` to better reflect its purpose.
- Update tool registration in `src/mcp_server/server.ts`.
- Add comprehensive documentation for the new `map_symbols_by_query` tool.
- Significantly enhance the `semantic_code_search.md` documentation with a detailed "Investigation Workflow", tool selection guide, KQL syntax, key principles, and examples.
- Improve the error message in `read_file.ts` for file not found errors.
- Standardize the `index` parameter description in `symbol_analysis.md`.

🤖 This commit was assisted by Gemini CLI