### PR TITLE
Boost documentation score in semantic search results

### DIFF
--- a/src/mcp_server/tools/semantic_code_search.ts
+++ b/src/mcp_server/tools/semantic_code_search.ts
@@ -58,9 +58,19 @@ export async function semanticCodeSearch(params: SemanticCodeSearchParams): Prom
 
   const esQuery: QueryDslQueryContainer = {
     bool: {
-      must
-    }
-  }
+      must,
+      should: [
+        {
+          term: {
+            type: {
+              value: 'doc',
+              boost: 2,
+            },
+          },
+        },
+      ],
+    },
+  };
 
   const response = await client.search({
     index: index || elasticsearchConfig.index,

--- a/tests/mcp_server/list_symbols_by_query.test.ts
+++ b/tests/mcp_server/list_symbols_by_query.test.ts
@@ -34,7 +34,7 @@ describe('list_symbols_by_query', () => {
     };
     (aggregateBySymbolsAndImports as jest.Mock).mockResolvedValue(mockAggregations);
 
-    const result = await listSymbolsByQuery({ kql: 'language: typescript' });
+    const result = await listSymbolsByQuery({ kql: 'language: typescript', size: 1000 });
 
     expect(aggregateBySymbolsAndImports).toHaveBeenCalledWith(
       {
@@ -49,7 +49,8 @@ describe('list_symbols_by_query', () => {
           ],
         },
       },
-      undefined
+      undefined,
+      1000
     );
 
     expect(JSON.parse(result.content[0].text as string)).toEqual(mockAggregations);
@@ -59,7 +60,11 @@ describe('list_symbols_by_query', () => {
     const mockAggregations = {};
     (aggregateBySymbolsAndImports as jest.Mock).mockResolvedValue(mockAggregations);
 
-    const result = await listSymbolsByQuery({ kql: 'language: typescript', index: 'my-index' });
+    const result = await listSymbolsByQuery({
+      kql: 'language: typescript',
+      index: 'my-index',
+      size: 1000,
+    });
 
     expect(aggregateBySymbolsAndImports).toHaveBeenCalledWith(
       {
@@ -74,7 +79,8 @@ describe('list_symbols_by_query', () => {
           ],
         },
       },
-      'my-index'
+      'my-index',
+      1000
     );
 
     expect(JSON.parse(result.content[0].text as string)).toEqual(mockAggregations);

--- a/tests/mcp_server/prompts/chain_of_investigation.test.ts
+++ b/tests/mcp_server/prompts/chain_of_investigation.test.ts
@@ -11,7 +11,8 @@ describe('startChainOfInvestigation', () => {
     if (typeof content === 'string' || !('text' in content)) {
       throw new Error('Expected content to be a ContentPart object with a text property');
     }
-    expect(content.text).toContain('Here is a chain of investigation workflow to help you with your task: "My test task"');
-    expect(content.text).toContain('## Workflow\n\nTest workflow');
+    expect(content.text).toContain('Use the workflow below to satisfy this task');
+    expect(content.text).toContain('My test task');
+    expect(content.text).toContain('Test workflow');
   });
 });

--- a/tests/mcp_server/semantic_code_search.test.ts
+++ b/tests/mcp_server/semantic_code_search.test.ts
@@ -59,6 +59,16 @@ describe('semantic_code_search', () => {
               },
             },
           ],
+          should: [
+            {
+              term: {
+                type: {
+                  value: 'doc',
+                  boost: 2,
+                },
+              },
+            },
+          ],
         },
       },
       from: 50,


### PR DESCRIPTION
## 🍒 Summary

This pull request improves the semantic search results by boosting the score of documentation-related content.

## 🛠️ Changes

- Modified `src/mcp_server/tools/semantic_code_search.ts` to add a `should` clause to the Elasticsearch query, boosting the score of documents with `type: 'doc'`.
- Updated `tests/mcp_server/semantic_code_search.test.ts` to reflect the new query structure.
- Fixed unrelated test failures in `tests/mcp_server/list_symbols_by_query.test.ts` and `tests/mcp_server/prompts/chain_of_investigation.test.ts`.

## 🎙️ Prompts

- "For the `semantic_code_search` Elasticsearch query, I would like to boost the score for docs that match the search results. I when documentation matches the semantic search query, it's should probably have higher precedence."
- "Couldn't we just do `{ term: { type: { value: "doc", boost: 2 } } }`, also where did you get the field "documentation"?"

🤖 This pull request was assisted by Gemini CLI
