### PR TITLE
Boost markdown files in semantic search

### DIFF
--- a/src/mcp_server/tools/semantic_code_search.ts
+++ b/src/mcp_server/tools/semantic_code_search.ts
@@ -62,8 +62,8 @@ export async function semanticCodeSearch(params: SemanticCodeSearchParams): Prom
       should: [
         {
           term: {
-            type: {
-              value: 'doc',
+            language: {
+              value: 'markdown',
               boost: 2,
             },
           },

--- a/tests/mcp_server/semantic_code_search.test.ts
+++ b/tests/mcp_server/semantic_code_search.test.ts
@@ -62,8 +62,8 @@ describe('semantic_code_search', () => {
           should: [
             {
               term: {
-                type: {
-                  value: 'doc',
+                language: {
+                  value: 'markdown',
                   boost: 2,
                 },
               },


### PR DESCRIPTION
## 🍒 Summary

This pull request updates the semantic search functionality to boost Markdown files. Previously, the boost was applied to documents with `type: doc`, and now it is correctly applied to `language: markdown`.

## 🛠️ Changes

- The Elasticsearch query in the `semantic_code_search` tool has been modified to apply a boost to documents where the `language` is `markdown`.
- The corresponding unit test has been updated to reflect the new query structure.

## 🎙️ Prompts

- "Currently the semantic_code_search tool boosts terms `type: doc` can we change that to `language: markdown`?"

🤖 This pull request was assisted by Gemini CLI
