### PR TITLE
feat(ci): docker release to push to ghcr

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,8 +27,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  packages: write
 
 concurrency:
   group: "release-scsi-mcp-${{ github.sha }}"
@@ -36,7 +34,9 @@ concurrency:
 jobs:
   docker:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 


### PR DESCRIPTION
## Changes

Improves docker release workflow. It builds the project's Docker image and publishes it to GitHub Container Registry (ghcr.io). The workflow supports multi-arch builds, semantic tagging (commit SHA, branch/latest, and Git tags).

No credentials are needed to be able to pull the docker image from the registry.

https://github.com/elastic/semantic-code-search-mcp-server/pkgs/container/semantic-code-search-mcp-server