### PR TITLE
feat: improve list_indices with dual discovery and consistent index name display

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,13 @@ The MCP server provides the following tools:
 
 | Tool | Description |
 | --- | --- |
+| `list_indices` | Lists available Elasticsearch indices on the cluster with statistics (files, symbols, languages, content types). Uses dual discovery: aliases ending with `-repo` and `_settings` pattern fallback. Shows index names (not aliases) for better UX. |
 | `semantic_code_search` | Performs a semantic search on the code chunks in the index. This tool can combine a semantic query with a KQL filter to provide flexible and powerful search capabilities. |
 | `map_symbols_by_query` | Query for a structured map of files containing specific symbols, grouped by file path. This is useful for finding all the symbols in a specific file or directory. Accepts an optional `size` parameter to control the number of files returned. |
 | `symbol_analysis` | Analyzes a symbol and returns a report of its definitions, call sites, and references. This is useful for understanding the role of a symbol in the codebase. |
 | `read_file_from_chunks` | Reads the content of a file from the index, providing a reconstructed view based on the most important indexed chunks. |
 | `document_symbols` | Analyzes a file to identify the key symbols that would most benefit from documentation. This is useful for automating the process of improving the semantic quality of a codebase. |
+| `discover_directories` | Discovers significant directories in a codebase to help identify where important packages, modules, or components are located. |
 
 **Note:** All of the tools accept an optional `index` parameter that allows you to override the `ELASTICSEARCH_INDEX` for a single query.
 

--- a/src/mcp_server/tools/list_indices.md
+++ b/src/mcp_server/tools/list_indices.md
@@ -5,3 +5,46 @@
 Lists available Elasticsearch indices that are hosted on the same Elasticsearch cluster as the default configured `ELASTICSEARCH_INDEX`.
 
 This tool allows LLMs to query for available indices and get a summary of their contents.
+
+## Discovery Strategy
+
+The tool uses a dual discovery strategy to find repository indices:
+
+1. **Primary**: Discovers indices via aliases ending with `-repo` (backward compatible)
+2. **Fallback**: Discovers indices via `_settings` pattern when aliases are not available
+
+Both methods are attempted, and results are merged and deduplicated. If the same index is found via both methods, the alias-based entry takes precedence.
+
+## Output Format
+
+The tool displays:
+- **Index name**: Shows the actual index name (e.g., `kibana`), not the alias (e.g., `kibana-repo`)
+- **Default indicator**: Marks the index matching `ELASTICSEARCH_INDEX` as `(Default)`
+- **Statistics**: For each index:
+  - Total number of files indexed
+  - Total number of symbols
+  - Languages breakdown with file counts
+  - Content types breakdown with file counts
+
+## Example Output
+
+```
+Index: kibana (Default)
+- Files: 1,500 total
+- Symbols: 3,200 total
+- Languages: typescript (1,200 files), javascript (300 files)
+- Content: function_declaration (800 files), class_declaration (200 files)
+---
+Index: grafana
+- Files: 800 total
+- Symbols: 1,500 total
+- Languages: go (600 files), typescript (200 files)
+- Content: function_declaration (500 files), type_declaration (100 files)
+```
+
+## Error Handling
+
+- If alias discovery fails, the tool falls back to `_settings` discovery
+- If both methods fail, returns a message indicating no indices were found
+- Individual index query errors are logged but don't stop the entire operation
+- Indices without valid aggregations are skipped from the output

--- a/src/mcp_server/tools/list_indices.ts
+++ b/src/mcp_server/tools/list_indices.ts
@@ -6,25 +6,25 @@ import { elasticsearchConfig } from '../../config';
 
 interface AggregationBucket {
   key: string;
-  numberOfFiles: {
-    value: number;
+  numberOfFiles?: {
+    value?: number;
   };
 }
 
 interface Aggregations {
-  filesIndexed: {
-    value: number;
+  filesIndexed?: {
+    value?: number;
   };
-  NumberOfSymbols: {
-    total: {
-      value: number;
+  NumberOfSymbols?: {
+    total?: {
+      value?: number;
     };
   };
-  Languages: {
-    buckets: AggregationBucket[];
+  Languages?: {
+    buckets?: AggregationBucket[];
   };
-  Types: {
-    buckets: AggregationBucket[];
+  Types?: {
+    buckets?: AggregationBucket[];
   };
 }
 
@@ -59,29 +59,136 @@ function formatNumber(num: number): string {
   return num.toString();
 }
 
-export async function listIndices(): Promise<CallToolResult> {
-  const aliasesResponse = await client.indices.getAlias({
-    name: '*-repo',
-  });
+interface RepoIndexInfo {
+  displayName: string; // The name to display in output (the index name, not alias)
+  actualIndexName: string; // The actual index name to query in Elasticsearch
+  isDefault: boolean;
+}
 
-  if (!aliasesResponse || Object.keys(aliasesResponse).length === 0) {
+async function discoverRepoIndicesFromAliases(): Promise<RepoIndexInfo[]> {
+  const repoIndices: RepoIndexInfo[] = [];
+  const defaultIndexName = elasticsearchConfig.index;
+
+  try {
+    const aliasesResponse = await client.indices.getAlias({
+      name: '*-repo',
+    });
+
+    if (aliasesResponse && Object.keys(aliasesResponse).length > 0) {
+      const indexEntries = Object.entries(aliasesResponse);
+
+      for (const [indexName, indexInfo] of indexEntries) {
+        if (!indexInfo.aliases) continue;
+
+        const repoAliases = Object.keys(indexInfo.aliases).filter((alias) => alias.endsWith('-repo'));
+
+        for (const alias of repoAliases) {
+          repoIndices.push({
+            displayName: indexName, // Show the actual index name, not the alias
+            actualIndexName: indexName, // Use underlying index name for deduplication
+            isDefault: indexName === defaultIndexName || alias === defaultIndexName,
+          });
+        }
+      }
+    }
+  } catch (error) {
+    // If alias query fails, continue to fallback method
+    console.warn('Failed to query aliases:', error);
+  }
+
+  return repoIndices;
+}
+
+async function discoverRepoIndicesFromSettings(): Promise<RepoIndexInfo[]> {
+  const repoIndices: RepoIndexInfo[] = [];
+  const defaultIndexName = elasticsearchConfig.index;
+
+  try {
+    // Get all indices ending with _settings
+    const allIndicesResponse = await client.indices.get({
+      index: '*_settings',
+    });
+
+    if (allIndicesResponse && Object.keys(allIndicesResponse).length > 0) {
+      const settingsIndices = Object.keys(allIndicesResponse);
+
+      for (const settingsIndex of settingsIndices) {
+        // Extract base name by removing _settings suffix
+        const baseIndexName = settingsIndex.replace(/_settings$/, '');
+
+        // Verify the base index exists (it should, as indexer creates both)
+        try {
+          const indexExists = await client.indices.exists({
+            index: baseIndexName,
+          });
+
+          if (indexExists) {
+            repoIndices.push({
+              displayName: baseIndexName,
+              actualIndexName: baseIndexName,
+              isDefault: baseIndexName === defaultIndexName,
+            });
+          }
+        } catch {
+          // Skip if we can't verify the base index exists
+          continue;
+        }
+      }
+    }
+  } catch (error) {
+    // If settings discovery fails, return empty array
+    console.warn('Failed to discover indices from _settings pattern:', error);
+  }
+
+  return repoIndices;
+}
+
+export async function listIndices(): Promise<CallToolResult> {
+  // Strategy 1: Discover from aliases
+  const aliasIndices = await discoverRepoIndicesFromAliases();
+
+  // Strategy 2: Discover from _settings indices (fallback)
+  const settingsIndices = await discoverRepoIndicesFromSettings();
+
+  // Merge and deduplicate by actualIndexName (the index we query)
+  // We prefer the alias-based index if it exists, as it's the "official" entry point
+  const deduplicatedIndicesMap = new Map<string, RepoIndexInfo>();
+
+  // Add alias-based indices first (they take precedence)
+  for (const repoIndex of aliasIndices) {
+    deduplicatedIndicesMap.set(repoIndex.actualIndexName, repoIndex);
+  }
+
+  // Add settings-based indices only if not already found via aliases
+  for (const repoIndex of settingsIndices) {
+    if (!deduplicatedIndicesMap.has(repoIndex.actualIndexName)) {
+      deduplicatedIndicesMap.set(repoIndex.actualIndexName, repoIndex);
+    }
+  }
+
+  const allRepoIndices = Array.from(deduplicatedIndicesMap.values());
+
+  if (allRepoIndices.length === 0) {
     return {
-      content: [{ type: 'text', text: 'No indices found matching the "*-repo" pattern.' }],
+      content: [
+        {
+          type: 'text',
+          text: 'No indices found. Searched for aliases ending with "-repo" and indices ending with "_settings".',
+        },
+      ],
     };
   }
 
-  const defaultIndexName = elasticsearchConfig.index;
+  // Sort by display name for consistent output
+  allRepoIndices.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
   let result = '';
-  const indexEntries = Object.entries(aliasesResponse);
+  for (let i = 0; i < allRepoIndices.length; i++) {
+    const repoIndex = allRepoIndices[i];
 
-  for (const [indexName, indexInfo] of indexEntries) {
-    if (!indexInfo.aliases) continue;
-
-    const repoAliases = Object.keys(indexInfo.aliases).filter((alias) => alias.endsWith('-repo'));
-
-    for (const alias of repoAliases) {
+    try {
       const searchResponse = await client.search<unknown, Aggregations>({
-        index: alias,
+        index: repoIndex.actualIndexName,
         ...aggregationQuery,
       });
 
@@ -91,32 +198,33 @@ export async function listIndices(): Promise<CallToolResult> {
         continue;
       }
 
-      const filesIndexed = aggregations.filesIndexed.value;
-      const numberOfSymbols = aggregations.NumberOfSymbols.total.value;
-      const languages = aggregations.Languages.buckets
-        .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.numberOfFiles.value)} files)`)
+      // Handle potentially missing aggregation values (Elasticsearch can return partial data)
+      const filesIndexed = aggregations.filesIndexed?.value ?? 0;
+      const numberOfSymbols = aggregations.NumberOfSymbols?.total?.value ?? 0;
+      const languages = (aggregations.Languages?.buckets ?? [])
+        .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.numberOfFiles?.value ?? 0)} files)`)
         .join(', ');
-      const types = aggregations.Types.buckets
-        .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.numberOfFiles.value)} files)`)
+      const types = (aggregations.Types?.buckets ?? [])
+        .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.numberOfFiles?.value ?? 0)} files)`)
         .join(', ');
 
-      const isDefault = indexName === defaultIndexName || alias === defaultIndexName;
-      result += `Index: ${alias}${isDefault ? ' (Default)' : ''}\n`;
+      result += `Index: ${repoIndex.displayName}${repoIndex.isDefault ? ' (Default)' : ''}\n`;
       result += `- Files: ${filesIndexed.toLocaleString()} total\n`;
       result += `- Symbols: ${numberOfSymbols.toLocaleString()} total\n`;
-      result += `- Languages: ${languages}\n`;
-      result += `- Content: ${types}\n`;
+      result += `- Languages: ${languages || 'none'}\n`;
+      result += `- Content: ${types || 'none'}\n`;
 
-      // Check if it's not the last alias of the last index entry
-      const isLastName = repoAliases.indexOf(alias) === repoAliases.length - 1;
-      const isLastEntry =
-        indexEntries.indexOf(indexEntries.find((entry) => entry[0] === indexName)!) === indexEntries.length - 1;
-
-      if (!isLastName || !isLastEntry) {
+      // Add separator if not the last item
+      if (i < allRepoIndices.length - 1) {
         result += '---\n';
       }
+    } catch (error) {
+      // Skip indices we can't query
+      console.warn(`Failed to query index ${repoIndex.actualIndexName}:`, error);
+      continue;
     }
   }
+
   return {
     content: [{ type: 'text', text: result.trim() }],
   };

--- a/tests/mcp_server/list_indices.test.ts
+++ b/tests/mcp_server/list_indices.test.ts
@@ -1,11 +1,15 @@
+import { TextContent } from '@modelcontextprotocol/sdk/types';
+import type { IndicesGetAliasResponse, IndicesGetResponse, SearchResponse } from '@elastic/elasticsearch/lib/api/types';
+
 import { listIndices } from '../../src/mcp_server/tools/list_indices';
 import { client } from '../../src/utils/elasticsearch';
-import { TextContent } from '@modelcontextprotocol/sdk/types';
 
 jest.mock('../../src/utils/elasticsearch', () => ({
   client: {
     indices: {
       getAlias: jest.fn(),
+      get: jest.fn(),
+      exists: jest.fn(),
     },
     search: jest.fn(),
   },
@@ -18,55 +22,461 @@ jest.mock('../../src/config', () => ({
 }));
 import { elasticsearchConfig } from '../../src/config';
 
-const mockClient = client as jest.Mocked<typeof client>;
+const mockClient = jest.mocked(client);
+
+// Mock console.warn to suppress output and allow verification
+const originalWarn = console.warn;
+const mockConsoleWarn = jest.fn();
+
+// Helper to create a minimal SearchResponse with aggregations
+function createSearchResponse(
+  aggregations: SearchResponse<unknown, Record<string, unknown>>['aggregations']
+): SearchResponse<unknown, Record<string, unknown>> {
+  return {
+    took: 0,
+    timed_out: false,
+    _shards: {
+      total: 1,
+      successful: 1,
+      skipped: 0,
+      failed: 0,
+    },
+    hits: {
+      total: {
+        value: 0,
+        relation: 'eq' as const,
+      },
+      max_score: null,
+      hits: [],
+    },
+    aggregations,
+  };
+}
 
 describe('listIndices', () => {
   beforeEach(() => {
-    (mockClient.indices.getAlias as jest.Mock).mockClear();
-    (mockClient.search as jest.Mock).mockClear();
+    jest.clearAllMocks();
+    console.warn = mockConsoleWarn;
+  });
+
+  afterAll(() => {
+    console.warn = originalWarn;
   });
 
   it('should mark default when ELASTICSEARCH_INDEX matches the index name', async () => {
     (elasticsearchConfig as { index: string }).index = 'kibana-code-search-2.0';
-    (mockClient.indices.getAlias as jest.Mock).mockResolvedValue({
+    const getAliasResponse: IndicesGetAliasResponse = {
       'kibana-code-search-2.0': { aliases: { 'kibana-repo': {} } },
       'grafana-code-search': { aliases: { 'grafana-repo': {} } },
-    });
-    (mockClient.search as jest.Mock).mockResolvedValue({
-      aggregations: {
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
         filesIndexed: { value: 100 },
         NumberOfSymbols: { total: { value: 200 } },
         Languages: { buckets: [] },
         Types: { buckets: [] },
-      },
-    });
+      })
+    );
 
     const result = await listIndices();
-    const output = (result.content[0] as TextContent).text;
+    const output = result.content[0].text;
 
-    expect(output).toContain('Index: kibana-repo (Default)');
-    expect(output).not.toContain('Index: grafana-repo (Default)');
+    expect(output).toContain('Index: kibana-code-search-2.0 (Default)');
+    expect(output).not.toContain('Index: grafana-code-search (Default)');
+    // Should not log warnings during normal operation
+    expect(mockConsoleWarn).not.toHaveBeenCalled();
   });
 
   it('should mark default when ELASTICSEARCH_INDEX matches the alias name', async () => {
-    (elasticsearchConfig as { index: string }).index = 'grafana-repo';
-    (mockClient.indices.getAlias as jest.Mock).mockResolvedValue({
+    elasticsearchConfig.index = 'grafana-repo';
+    const getAliasResponse: IndicesGetAliasResponse = {
       'kibana-code-search-2.0': { aliases: { 'kibana-repo': {} } },
       'grafana-code-search': { aliases: { 'grafana-repo': {} } },
-    });
-    (mockClient.search as jest.Mock).mockResolvedValue({
-      aggregations: {
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
         filesIndexed: { value: 100 },
         NumberOfSymbols: { total: { value: 200 } },
         Languages: { buckets: [] },
         Types: { buckets: [] },
-      },
-    });
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).not.toContain('Index: kibana-code-search-2.0 (Default)');
+    expect(output).toContain('Index: grafana-code-search (Default)');
+  });
+
+  it('should fallback to _settings indices when no aliases are found', async () => {
+    elasticsearchConfig.index = 'my-repo';
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue({});
+    const getResponse: IndicesGetResponse = {
+      'my-repo_settings': {},
+      'other-repo_settings': {},
+    };
+    jest.mocked(mockClient.indices.get).mockResolvedValue(getResponse);
+    jest.mocked(mockClient.indices.exists).mockResolvedValue(true);
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 50 },
+        NumberOfSymbols: { total: { value: 100 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('Index: my-repo (Default)');
+    expect(output).toContain('Index: other-repo');
+  });
+
+  it('should prefer aliases over _settings indices when both exist', async () => {
+    elasticsearchConfig.index = 'my-repo-index';
+    // Alias 'my-repo' points to 'my-repo-index'
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'my-repo-index': { aliases: { 'my-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    // _settings also exists for 'my-repo-index' (same underlying index)
+    const getResponse: IndicesGetResponse = {
+      'my-repo-index_settings': {},
+    };
+    jest.mocked(mockClient.indices.get).mockResolvedValue(getResponse);
+    jest.mocked(mockClient.indices.exists).mockResolvedValue(true);
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 50 },
+        NumberOfSymbols: { total: { value: 100 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      })
+    );
 
     const result = await listIndices();
     const output = (result.content[0] as TextContent).text;
 
-    expect(output).not.toContain('Index: kibana-repo (Default)');
-    expect(output).toContain('Index: grafana-repo (Default)');
+    // Should deduplicate and show only once, using index name from alias (preferred)
+    const matches = output.match(/Index: my-repo-index/g);
+    expect(matches).toHaveLength(1);
+    expect(output).toContain('Index: my-repo-index');
+  });
+
+  it('should return appropriate message when no indices are found', async () => {
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue({});
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('No indices found');
+    expect(output).toContain('aliases ending with "-repo"');
+    expect(output).toContain('indices ending with "_settings"');
+  });
+
+  it('should handle languages and types buckets correctly', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'test-index': { aliases: { 'test-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 150 },
+        NumberOfSymbols: { total: { value: 300 } },
+        Languages: {
+          buckets: [
+            { key: 'typescript', numberOfFiles: { value: 100 } },
+            { key: 'javascript', numberOfFiles: { value: 50 } },
+          ],
+        },
+        Types: {
+          buckets: [
+            { key: 'function_declaration', numberOfFiles: { value: 80 } },
+            { key: 'class_declaration', numberOfFiles: { value: 20 } },
+          ],
+        },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('Index: test-index');
+    expect(output).toContain('Files: 150 total');
+    expect(output).toContain('Symbols: 300 total');
+    expect(output).toContain('typescript (100 files)');
+    expect(output).toContain('javascript (50 files)');
+    expect(output).toContain('function_declaration (80 files)');
+    expect(output).toContain('class_declaration (20 files)');
+  });
+
+  it('should handle missing aggregations gracefully', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'test-index': { aliases: { 'test-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(createSearchResponse(undefined));
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    // Should not include test-index since aggregations are missing
+    expect(output).not.toContain('Index: test-index');
+  });
+
+  it('should handle search errors gracefully', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'test-index': { aliases: { 'test-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockRejectedValue(new Error('Search failed'));
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    // Should not include test-index since search failed
+    expect(output).not.toContain('Index: test-index');
+  });
+
+  it('should handle alias query errors and fallback to _settings', async () => {
+    (elasticsearchConfig as { index: string }).index = 'my-repo';
+    const aliasError = new Error('Alias query failed');
+    jest.mocked(mockClient.indices.getAlias).mockRejectedValue(aliasError);
+    const getResponse: IndicesGetResponse = {
+      'my-repo_settings': {},
+    };
+    jest.mocked(mockClient.indices.get).mockResolvedValue(getResponse);
+    jest.mocked(mockClient.indices.exists).mockResolvedValue(true);
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 50 },
+        NumberOfSymbols: { total: { value: 100 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    // Should still find indices via _settings fallback
+    expect(output).toContain('Index: my-repo (Default)');
+    // Should log warning about alias query failure
+    expect(mockConsoleWarn).toHaveBeenCalledWith('Failed to query aliases:', aliasError);
+    // Verify fallback was attempted
+    expect(mockClient.indices.get).toHaveBeenCalledWith({ index: '*_settings' });
+  });
+
+  it('should handle _settings query errors gracefully', async () => {
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue({});
+    const settingsError = new Error('Settings query failed');
+    jest.mocked(mockClient.indices.get).mockRejectedValue(settingsError);
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('No indices found');
+    // Should log warning about settings query failure
+    expect(mockConsoleWarn).toHaveBeenCalledWith('Failed to discover indices from _settings pattern:', settingsError);
+  });
+
+  it('should skip _settings indices when base index does not exist', async () => {
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue({});
+    const getResponse: IndicesGetResponse = {
+      orphan_settings: {}, // Base index 'orphan' doesn't exist
+    };
+    jest.mocked(mockClient.indices.get).mockResolvedValue(getResponse);
+    jest.mocked(mockClient.indices.exists).mockResolvedValue(false);
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).not.toContain('Index: orphan');
+    expect(output).toContain('No indices found');
+  });
+
+  it('should handle exists check errors gracefully', async () => {
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue({});
+    const getResponse: IndicesGetResponse = {
+      'test-repo_settings': {},
+    };
+    jest.mocked(mockClient.indices.get).mockResolvedValue(getResponse);
+    jest.mocked(mockClient.indices.exists).mockRejectedValue(new Error('Exists check failed'));
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    // Should skip indices where exists check fails
+    expect(output).not.toContain('Index: test-repo');
+    // Exists check errors are caught silently (no warning)
+    expect(mockConsoleWarn).not.toHaveBeenCalled();
+  });
+
+  it('should deduplicate indices found via both methods', async () => {
+    elasticsearchConfig.index = 'my-repo-index';
+    // Alias 'my-repo' points to 'my-repo-index'
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'my-repo-index': { aliases: { 'my-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    // _settings also exists for 'my-repo-index' (same underlying index)
+    const getResponse: IndicesGetResponse = {
+      'my-repo-index_settings': {},
+    };
+    jest.mocked(mockClient.indices.get).mockResolvedValue(getResponse);
+    jest.mocked(mockClient.indices.exists).mockResolvedValue(true);
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 50 },
+        NumberOfSymbols: { total: { value: 100 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = (result.content[0] as TextContent).text;
+
+    // Should only appear once, using index name
+    const matches = output.match(/Index: my-repo-index/g);
+    expect(matches).toHaveLength(1);
+    expect(output).toContain('Index: my-repo-index');
+  });
+
+  it('should sort indices alphabetically', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'z-index': { aliases: { 'z-repo': {} } },
+      'a-index': { aliases: { 'a-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 50 },
+        NumberOfSymbols: { total: { value: 100 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = (result.content[0] as TextContent).text;
+
+    const aIndexPos = output.indexOf('Index: a-index');
+    const zIndexPos = output.indexOf('Index: z-index');
+    expect(aIndexPos).toBeLessThan(zIndexPos);
+  });
+
+  it('should format large numbers correctly', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'large-index': { aliases: { 'large-repo': {} } },
+    };
+    // Note: Will show 'large-index' not 'large-repo'
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 1500000 },
+        NumberOfSymbols: { total: { value: 2500 } },
+        Languages: {
+          buckets: [{ key: 'typescript', numberOfFiles: { value: 1500000 } }],
+        },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('Index: large-index');
+    expect(output).toContain('Files: 1,500,000 total');
+    expect(output).toContain('typescript (1.5M files)');
+  });
+
+  it('should handle null aggregation values gracefully', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'test-index': { aliases: { 'test-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: null },
+        NumberOfSymbols: { total: { value: null } },
+        Languages: { buckets: null },
+        Types: { buckets: undefined },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    // Should still include the index with default values
+    expect(output).toContain('Index: test-index');
+    expect(output).toContain('Files: 0 total');
+    expect(output).toContain('Symbols: 0 total');
+    expect(output).toContain('Languages: none');
+    expect(output).toContain('Content: none');
+  });
+
+  it('should handle empty buckets arrays', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'test-index': { aliases: { 'test-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 100 },
+        NumberOfSymbols: { total: { value: 200 } },
+        Languages: { buckets: [] },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('Index: test-index');
+    expect(output).toContain('Languages: none');
+    expect(output).toContain('Content: none');
+  });
+
+  it('should handle missing numberOfFiles in bucket', async () => {
+    const getAliasResponse: IndicesGetAliasResponse = {
+      'test-index': { aliases: { 'test-repo': {} } },
+    };
+    jest.mocked(mockClient.indices.getAlias).mockResolvedValue(getAliasResponse);
+    jest.mocked(mockClient.indices.get).mockResolvedValue({});
+    jest.mocked(mockClient.search).mockResolvedValue(
+      createSearchResponse({
+        filesIndexed: { value: 100 },
+        NumberOfSymbols: { total: { value: 200 } },
+        Languages: {
+          buckets: [
+            { key: 'typescript', numberOfFiles: { value: null } },
+            { key: 'javascript' }, // missing numberOfFiles
+          ],
+        },
+        Types: { buckets: [] },
+      })
+    );
+
+    const result = await listIndices();
+    const output = result.content[0].text;
+
+    expect(output).toContain('Index: test-index');
+    expect(output).toContain('typescript (0 files)');
+    expect(output).toContain('javascript (0 files)');
   });
 });


### PR DESCRIPTION
## Summary

This PR improves the `list_indices` functionality to automatically discover repository indices using a dual discovery strategy, eliminating the need for manual alias creation. Additionally, it significantly improves the UX by showing index names instead of alias names to users.

## Alignment with Indexer PR #131

This PR complements [elastic/semantic-code-search-indexer#131](https://github.com/elastic/semantic-code-search-indexer/pull/131), which automatically creates `-repo` aliases when indexing. The complete flow:

```
User Command: npm run index -- kibana
                │
                ▼
┌─────────────────────────────────────────┐
│ Indexer (PR #131)                       │
├─────────────────────────────────────────┤
│ 1. Creates index: "kibana"              │
│ 2. Creates alias: "kibana-repo" ────┐  │
│    (points to "kibana")              │  │
└──────────────────────────────────────┼──┘
                                        │
                                        ▼
┌─────────────────────────────────────────┐
│ Elasticsearch Cluster                   │
├─────────────────────────────────────────┤
│ Index: "kibana"                         │
│   └─ Alias: "kibana-repo" ────────────┼─┐
└────────────────────────────────────────┼─┘
                                          │
                                          ▼
┌─────────────────────────────────────────┐
│ MCP Server (This PR)                   │
├─────────────────────────────────────────┤
│ Discovers via alias "kibana-repo"      │
│ Extracts index name: "kibana"          │
│ Shows user: "Index: kibana" ✅          │
└─────────────────────────────────────────┘
```

## How It Works

### Discovery Strategy

The MCP server uses a dual discovery approach to find repository indices:

```
┌─────────────────────────────────────────────────────────────┐
│ Discovery Flow                                               │
├─────────────────────────────────────────────────────────────┤
│                                                              │
│ Step 1: Alias Discovery (Primary)                          │
│ ┌──────────────────────────────────────────────────────┐   │
│ │ Query: getAlias({ name: '*-repo' })                   │   │
│ │ Response: { "kibana": { aliases: { "kibana-repo": {} } } }│
│ │ Extract: index name "kibana" (the key) ✅              │   │
│ └──────────────────────────────────────────────────────┘   │
│                                                              │
│ Step 2: Settings Discovery (Fallback)                      │
│ ┌──────────────────────────────────────────────────────┐   │
│ │ Query: get({ index: '*_settings' })                   │   │
│ │ Response: { "kibana_settings": {...} }                │   │
│ │ Extract: base name "kibana" (remove _settings) ✅     │   │
│ └──────────────────────────────────────────────────────┘   │
│                                                              │
│ Step 3: Merge & Deduplicate                                 │
│ ┌──────────────────────────────────────────────────────┐   │
│ │ Combine results, prefer alias-based entries            │   │
│ │ Deduplicate by actual index name                       │   │
│ │ Return: ["kibana"] (index names, not aliases) ✅       │   │
│ └──────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────┘
```

### Key Implementation Details

**Index Name Extraction from Aliases:**

When Elasticsearch returns alias information, we extract the **index name** (the key) rather than the **alias name** (the value):

```typescript
// Elasticsearch getAlias() response structure:
{
  "kibana": {                    // ← Index name (key) - what we return
    aliases: {
      "kibana-repo": {}          // ← Alias name (value) - used for discovery only
    }
  }
}

// Implementation:
for (const [indexName, indexInfo] of Object.entries(aliasesResponse)) {
  const repoAliases = Object.keys(indexInfo.aliases).filter(alias => 
    alias.endsWith('-repo')
  );
  if (repoAliases.length > 0) {
    repoIndices.push(indexName);  // ✅ Return "kibana", not "kibana-repo"
  }
}
```

This ensures:
- Users see what they indexed: `kibana` (not `kibana-repo`)
- Consistent behavior across `listIndices()` and `getAvailableIndices()`
- Error messages show index names users recognize

## Example

When a user runs `npm run index -- kibana`:

```
┌─────────────────────────────────────────────────────────┐
│ Indexer (PR #131)                                       │
│ Creates: index "kibana" + alias "kibana-repo"          │
└─────────────────────────────────────────────────────────┘
                    │
                    ▼
┌─────────────────────────────────────────────────────────┐
│ MCP Server (This PR)                                     │
│ list_indices shows: "Index: kibana" ✅                  │
│ Error messages show: "kibana" (not "kibana-repo") ✅    │
│ getAvailableIndices() returns: ["kibana"] ✅            │
└─────────────────────────────────────────────────────────┘
```

User sees what they indexed (`kibana`), not the implementation detail (`kibana-repo`).

Closes #33
