### PR TITLE
fix: adopt locations-first index model (_locations join)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This project includes a Model Context Protocol (MCP) server that exposes the ind
 
 You must index your code base with the Semantic Code Search Indexer found here: https://github.com/elastic/semantic-code-search-indexer
 
+### Index model expected by this MCP server
+
+This MCP server expects the **locations-first** index model from indexer PR `elastic/semantic-code-search-indexer#135`:
+
+- `<index>` stores **content-deduplicated chunk documents** (semantic search + metadata).
+- `<index>_locations` stores **one document per chunk occurrence** (file path + line ranges + directory/git metadata) and references chunks by `chunk_id`.
+
+Several tools query `<index>_locations` and join back to `<index>` via `chunk_id` (typically using `mget`).
+
 ## Running with Docker
 
 The easiest way to run the MCP server is with Docker. The server is available on Docker Hub as `simianhacker/semantic-code-search-mcp-server`.

--- a/docs/prompts/optimize-list_symbols_by_query-response.md
+++ b/docs/prompts/optimize-list_symbols_by_query-response.md
@@ -1,10 +1,35 @@
-## Problem Statement
+## Status
 
-I would like to change the output from `map_symbols_by_query` so the `symbols` and `imports` are grouped by `kind`. 
+This prompt document is **already implemented**: `map_symbols_by_query` returns `symbols`, `imports`, and `exports` grouped by their respective `kind`/`type`.
 
-## Current Behavior
+## Current Behavior (grouped output)
 
-The current output looks something like this:
+Output is a JSON object keyed by `filePath`. Each file contains grouped `symbols`/`imports`/`exports`:
+
+```JSON
+{
+  "src/example.ts": {
+    "symbols": {
+      "function.call": [{ "name": "describe", "line": 10 }],
+      "variable.name": [{ "name": "testCases", "line": 12 }]
+    },
+    "imports": {
+      "module": [{ "path": "@kbn/foo", "symbols": ["bar"] }]
+    },
+    "exports": {
+      "named": [{ "name": "myFunction" }]
+    }
+  }
+}
+```
+
+### Note (locations-first indices)
+
+Per-file association is computed from `<index>_locations` (by aggregating `filePath` → `chunk_id`). Symbols/imports/exports are read from `<index>` and joined via `chunk_id`.
+
+## Historical Behavior (pre-grouped output)
+
+The previous output shape grouped symbols as a single list (each entry had a `kind` field):
 
 ```JSON
 {

--- a/src/elasticsearch/directory_discovery.ts
+++ b/src/elasticsearch/directory_discovery.ts
@@ -1,6 +1,10 @@
 import { Client } from '@elastic/elasticsearch';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 
+function getLocationsIndexName(index: string): string {
+  return `${index}_locations`;
+}
+
 export interface DirectoryInfo {
   path: string;
   fileCount: number;
@@ -14,28 +18,42 @@ interface DirectoryAggregationBucket {
   key: string;
   doc_count: number;
   file_count: { value: number };
-  symbol_count: { count: { value: number } };
-  languages: { buckets: Array<{ key: string; doc_count: number }> };
-  top_kinds: { buckets: Array<{ key: string; doc_count: number }> };
-  score: { value: number };
+  top_chunks: { buckets: Array<{ key: string; doc_count: number }> };
 }
 
 interface DirectoryAggregationResponse {
   buckets: DirectoryAggregationBucket[];
 }
 
+/**
+ * Discovers significant directories via `<index>_locations` (one document per chunk occurrence).
+ */
 export async function discoverSignificantDirectories(
   client: Client,
   index: string,
   options: {
-    query?: QueryDslQueryContainer;
+    chunkIds?: string[];
+    locationQuery?: QueryDslQueryContainer;
     minFiles?: number;
     maxResults?: number;
   }
 ): Promise<DirectoryInfo[]> {
+  const locationsIndex = getLocationsIndexName(index);
+  const uniqueChunkIds = Array.from(new Set(options.chunkIds ?? [])).filter(
+    (id) => typeof id === 'string' && id.length
+  );
+
+  const queryMust: QueryDslQueryContainer[] = [];
+  if (options.locationQuery) {
+    queryMust.push(options.locationQuery);
+  }
+  if (uniqueChunkIds.length > 0) {
+    queryMust.push({ terms: { chunk_id: uniqueChunkIds } });
+  }
+
   const response = await client.search({
-    index,
-    query: options.query || { match_all: {} },
+    index: locationsIndex,
+    query: queryMust.length > 0 ? { bool: { must: queryMust } } : { match_all: {} },
     size: 0,
     aggs: {
       directories: {
@@ -43,44 +61,72 @@ export async function discoverSignificantDirectories(
           field: 'directoryPath',
           size: options.maxResults || 50,
           min_doc_count: options.minFiles || 3,
-          order: { score: 'desc' },
+          order: { _count: 'desc' },
         },
         aggs: {
-          score: {
-            avg: {
-              script: { source: '_score' },
-            },
-          },
           file_count: {
             cardinality: { field: 'filePath' },
           },
-          symbol_count: {
-            nested: { path: 'symbols' },
-            aggs: {
-              count: { value_count: { field: 'symbols.name' } },
+          top_chunks: {
+            terms: {
+              field: 'chunk_id',
+              size: 200,
             },
-          },
-          languages: {
-            terms: { field: 'language', size: 10 },
-          },
-          top_kinds: {
-            terms: { field: 'kind', size: 5 },
           },
         },
       },
     },
   });
 
-  const buckets = (response.aggregations?.directories as DirectoryAggregationResponse)?.buckets || [];
+  const buckets = (response.aggregations as unknown as { directories?: DirectoryAggregationResponse })?.directories
+    ?.buckets;
 
-  return buckets.map((bucket) => {
+  const chunkIdsForEnrichment = Array.from(
+    new Set((buckets ?? []).flatMap((b) => b.top_chunks?.buckets?.map((c) => c.key) ?? []))
+  );
+  const mgetResponse = await client.mget({
+    index,
+    ids: chunkIdsForEnrichment,
+  });
+  // Note: chunkIdsForEnrichment is bounded by (maxResults * 200) due to the `top_chunks` agg size.
+  // Keep an eye on this if maxResults or top_chunks size increases.
+  type ChunkEnrichment = { language: string; kind?: string; symbols?: Array<unknown> };
+  const chunksById: Record<string, ChunkEnrichment> = {};
+  for (const doc of mgetResponse.docs) {
+    if (!('found' in doc) || !doc.found) continue;
+    if (typeof doc._id !== 'string') continue;
+    if (!doc._source) continue;
+    chunksById[doc._id] = doc._source as ChunkEnrichment;
+  }
+
+  return (buckets ?? []).map((bucket) => {
+    const bucketChunkIds = (bucket.top_chunks?.buckets ?? []).map((b) => b.key);
+    const languages: Record<string, number> = {};
+    const kinds: Record<string, number> = {};
+    let symbolCount = 0;
+
+    for (const id of bucketChunkIds) {
+      const chunk = chunksById[id];
+      if (!chunk) continue;
+      languages[chunk.language] = (languages[chunk.language] ?? 0) + 1;
+      if (chunk.kind) {
+        kinds[chunk.kind] = (kinds[chunk.kind] ?? 0) + 1;
+      }
+      symbolCount += chunk.symbols?.length ?? 0;
+    }
+
+    const topKinds = Object.entries(kinds)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([k]) => k);
+
     return {
       path: bucket.key,
       fileCount: bucket.file_count.value,
-      symbolCount: bucket.symbol_count.count.value,
-      languages: bucket.languages.buckets.map((b) => b.key),
-      topKinds: bucket.top_kinds.buckets.map((b) => b.key),
-      score: bucket.score.value,
+      symbolCount,
+      languages: Object.keys(languages).slice(0, 10),
+      topKinds,
+      score: bucket.doc_count,
     };
   });
 }

--- a/src/mcp_server/prompts/chain_of_investigation.workflow.md
+++ b/src/mcp_server/prompts/chain_of_investigation.workflow.md
@@ -14,11 +14,22 @@
 - Structured output with line numbers and imports
 - Best for: Finding files using specific symbols, co-occurrence patterns
 
+### Note (locations-first indices)
+
+This MCP server uses a locations-first Elasticsearch model:
+
+- Chunk-level fields (e.g. `language`, `kind`, `content`, `symbols`) live in `<index>`.
+- File-level fields (e.g. `filePath`, `directoryPath`, `startLine`, `endLine`) live in `<index>_locations`.
+
+Implication: a KQL predicate like `filePath: *test*` is evaluated via `<index>_locations` and then joined back to `<index>` via `chunk_id`.
+
 ### semantic_code_search
 **For discovering symbols**
 - Returns top 25 snippets with relevance scores
 - Good for conceptual queries
 - Best for: "How does X work?", exploring unfamiliar code
+
+**Important**: If your request is **KQL-only** and the KQL references file-level fields (like `filePath`), `semantic_code_search` may require a semantic `query` to establish a bounded candidate set. If you really want a filePath-only exploration, prefer `map_symbols_by_query` or `discover_directories`.
 
 ### symbol_analysis
 **Deep dive on one symbol**

--- a/src/mcp_server/tools/discover_directories.md
+++ b/src/mcp_server/tools/discover_directories.md
@@ -53,6 +53,8 @@ Returns a ranked list of directories with:
 - **Languages**: Programming languages used
 - **Score**: Average score of matches
 
+**Note (locations-first indices):** Directory and file-level information is derived from `<index>_locations` (one document per chunk occurrence). The tool may join to `<index>` via `chunk_id` to enrich results (e.g. languages / symbol counts).
+
 ## Example Output
 ```
 Found 2 significant directories:

--- a/src/mcp_server/tools/document_symbols.md
+++ b/src/mcp_server/tools/document_symbols.md
@@ -8,6 +8,10 @@ This tool is designed to be used in an automated workflow for improving the sema
 
 An AI coding agent can use this tool to get a focused list of symbols to document, and then generate JSDoc comments for each one.
 
+## Notes (locations-first indices)
+
+Per-file symbol listings are resolved via `<index>_locations` (mapping `filePath` → `chunk_id`) and then joined to `<index>` by `chunk_id` to read chunk-level symbol metadata.
+
 ## Parameters
 
 - `filePath` (`string`): The relative path to the project of the file to analyze.

--- a/src/mcp_server/tools/list_indices.md
+++ b/src/mcp_server/tools/list_indices.md
@@ -5,3 +5,20 @@
 Lists available Elasticsearch indices that are hosted on the same Elasticsearch cluster as the default configured `ELASTICSEARCH_INDEX`.
 
 This tool allows LLMs to query for available indices and get a summary of their contents.
+
+## Notes (locations-first indices)
+
+This MCP server expects the locations-first model:
+
+- `<index>`: content-deduplicated chunk documents
+- `<index>_locations`: one document per chunk occurrence, including `filePath`
+
+For this tool, **file counts are computed from `<index>_locations`** using a `cardinality(filePath)` aggregation, because chunk documents do not store per-file metadata.
+
+## Output
+
+Returns a human-readable list of indices with:
+
+- Files: approximate count of unique file paths in `<index>_locations`
+- Symbols: approximate unique symbol count from `<index>` (nested `symbols`)
+- Languages / Content: rough breakdowns from `<index>`

--- a/src/mcp_server/tools/map_symbols_by_query.md
+++ b/src/mcp_server/tools/map_symbols_by_query.md
@@ -16,6 +16,15 @@ Use the `kql` parameter for complex queries:
 
 **Important**: You cannot use both `directory` and `kql` together - choose the one that fits your need.
 
+## Notes (locations-first indices)
+
+This MCP server expects the locations-first model:
+
+- `<index>`: content-deduplicated chunk documents (symbols/imports/exports live here)
+- `<index>_locations`: one document per chunk occurrence (filePath/directoryPath live here)
+
+When your KQL includes file-level fields (like `filePath`), those predicates are evaluated against `<index>_locations` and then joined back to `<index>` via `chunk_id`.
+
 ## Typical Workflow
 1. `discover_directories` → finds "src/platform/packages/kbn-esql-utils"
 2. `map_symbols_by_query` → explore that directory with `{ "directory": "src/platform/packages/kbn-esql-utils" }`

--- a/src/mcp_server/tools/map_symbols_by_query.ts
+++ b/src/mcp_server/tools/map_symbols_by_query.ts
@@ -1,12 +1,17 @@
 import { z } from 'zod';
 import { fromKueryExpression, toElasticsearchQuery } from '../../../libs/es-query';
 import {
-  aggregateBySymbolsAndImports,
+  client,
+  getChunksById,
+  getLocationsIndexName,
   isIndexNotFoundError,
   formatIndexNotFoundError,
   elasticsearchConfig,
 } from '../../utils/elasticsearch';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types';
+import { splitKqlNodeByStorage } from '../../utils/kql_scoping';
+
+const MAX_CHUNK_QUERY_SIZE = 10000;
 
 /**
  * The Zod schema for the `mapSymbolsByQuery` tool.
@@ -93,10 +98,125 @@ export async function mapSymbolsByQuery(params: MapSymbolsByQueryParams): Promis
   const kql = validateAndBuildQuery(params);
 
   const ast = fromKueryExpression(kql);
-  const dsl = toElasticsearchQuery(ast);
+  const split = splitKqlNodeByStorage(ast);
+  const chunkQuery = split.chunkNode ? toElasticsearchQuery(split.chunkNode) : undefined;
+  const locationQuery = split.locationNode ? toElasticsearchQuery(split.locationNode) : undefined;
 
   try {
-    const results = await aggregateBySymbolsAndImports(dsl, index, size);
+    const baseIndex = index || elasticsearchConfig.index;
+    const locationsIndex = getLocationsIndexName(baseIndex);
+
+    const chunkIds =
+      chunkQuery != null
+        ? (
+            await client.search({
+              index: baseIndex,
+              query: chunkQuery,
+              // We use a higher limit here than some other tools because we may need to join many chunk IDs
+              // with locations for large repositories. Reducing this limit risks missing relevant chunks.
+              size: MAX_CHUNK_QUERY_SIZE,
+              _source: false,
+            })
+          ).hits.hits
+            .map((h) => h._id)
+            .filter((id): id is string => typeof id === 'string' && id.length > 0)
+        : undefined;
+
+    const locationMust = [
+      ...(locationQuery ? [locationQuery] : []),
+      ...(chunkIds && chunkIds.length > 0 ? [{ terms: { chunk_id: chunkIds } }] : []),
+    ];
+
+    const response = await client.search({
+      index: locationsIndex,
+      query: locationMust.length > 0 ? { bool: { must: locationMust } } : { match_all: {} },
+      size: 0,
+      aggs: {
+        files: {
+          terms: {
+            field: 'filePath',
+            size: size ?? 1000,
+          },
+          aggs: {
+            chunks: {
+              terms: {
+                field: 'chunk_id',
+                size: 2000,
+              },
+              aggs: {
+                sample: {
+                  top_hits: {
+                    size: 1,
+                    _source: ['startLine'],
+                    sort: [{ startLine: { order: 'asc' } }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const buckets = (
+      response.aggregations as unknown as {
+        files?: {
+          buckets?: Array<{
+            key: string;
+            chunks?: { buckets?: Array<{ key: string; sample?: { hits?: { hits?: Array<{ _source?: unknown }> } } }> };
+          }>;
+        };
+      }
+    )?.files?.buckets;
+
+    const allChunkIds = Array.from(new Set((buckets ?? []).flatMap((b) => b.chunks?.buckets?.map((c) => c.key) ?? [])));
+    const chunksById = await getChunksById(allChunkIds, { index: baseIndex });
+
+    const results: Record<
+      string,
+      {
+        symbols: Record<string, Array<{ name: string; line: number }>>;
+        imports: Record<string, Array<{ path: string; symbols?: string[] }>>;
+        exports: Record<string, Array<{ name: string; target?: string }>>;
+      }
+    > = {};
+
+    for (const fileBucket of buckets ?? []) {
+      const filePath = fileBucket.key;
+      const symbols: Record<string, Array<{ name: string; line: number }>> = {};
+      const imports: Record<string, Array<{ path: string; symbols?: string[] }>> = {};
+      const exports: Record<string, Array<{ name: string; target?: string }>> = {};
+
+      for (const chunkBucket of fileBucket.chunks?.buckets ?? []) {
+        const chunkId = chunkBucket.key;
+        const chunk = chunksById[chunkId];
+        if (!chunk) continue;
+
+        const startLine = (chunkBucket.sample?.hits?.hits?.[0]?._source as { startLine?: unknown } | undefined)
+          ?.startLine;
+        const line = typeof startLine === 'number' ? startLine : 0;
+
+        for (const s of chunk.symbols ?? []) {
+          const kind = s.kind ?? 'symbol';
+          if (!symbols[kind]) symbols[kind] = [];
+          symbols[kind].push({ name: s.name, line });
+        }
+
+        for (const imp of chunk.imports ?? []) {
+          const type = imp.type;
+          if (!imports[type]) imports[type] = [];
+          imports[type].push({ path: imp.path, symbols: imp.symbols });
+        }
+
+        for (const exp of chunk.exports ?? []) {
+          const type = exp.type;
+          if (!exports[type]) exports[type] = [];
+          exports[type].push({ name: exp.name, ...(exp.target ? { target: exp.target } : {}) });
+        }
+      }
+
+      results[filePath] = { symbols, imports, exports };
+    }
 
     return {
       content: [{ type: 'text', text: JSON.stringify(results) }],

--- a/src/mcp_server/tools/read_file.md
+++ b/src/mcp_server/tools/read_file.md
@@ -1,7 +1,7 @@
 Reconstructs file content from indexed code chunks, presenting a single string that mirrors the original file's structure as closely as possible.
 
 ## Parameters
-- `filePaths` (`string[]`): An array of relative file paths to reconstruct.
+- `filePaths` (`string[]`): An array of file paths to reconstruct (typically repository-relative, as stored in the index).
 - `index` (`string`, optional): The specific Elasticsearch index to query.
 
 ## Returns
@@ -34,3 +34,5 @@ process.exit(1)
 ```
 
 **Note:** The reconstruction is based on indexed code chunks. While it aims to be accurate, it may not be a perfect 1:1 representation of the original file. Requires the same `index` used in the initial `semantic_code_search` to maintain context.
+
+**Note (locations-first indices):** This tool reconstructs files by querying `<index>_locations` for `(filePath, startLine, endLine, chunk_id)` and then fetching the chunk text from the primary index via `chunk_id`.

--- a/src/mcp_server/tools/read_file.ts
+++ b/src/mcp_server/tools/read_file.ts
@@ -1,11 +1,18 @@
 import { z } from 'zod';
-import { client, elasticsearchConfig, isIndexNotFoundError, formatIndexNotFoundError } from '../../utils/elasticsearch';
+import {
+  client,
+  elasticsearchConfig,
+  isIndexNotFoundError,
+  formatIndexNotFoundError,
+  getChunksById,
+  getLocationsIndexName,
+} from '../../utils/elasticsearch';
 import { Sort } from '@elastic/elasticsearch/lib/api/types';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types';
 
 /**
  * The Zod schema for the `readFile` tool.
- * @property {string[]} filePaths - An array of one or more absolute file paths to read.
+ * @property {string[]} filePaths - An array of one or more file paths (typically repository-relative) to read.
  */
 export const readFileSchema = z.object({
   filePaths: z.array(z.string()).nonempty(),
@@ -15,20 +22,14 @@ export const readFileSchema = z.object({
 /**
  * @interface CodeChunkHit
  * @description Defines the structure of a search hit from Elasticsearch, including the source document and sort values.
- * @property {object} _source - The source document of the code chunk.
- * @property {string} _source.filePath - The path to the file.
- * @property {string} _source.content - The content of the code chunk.
- * @property {number} _source.startLine - The starting line number of the chunk.
- * @property {number} _source.endLine - The ending line number of the chunk.
- * @property {(string | number)[]} sort - The sort values for search_after pagination.
  */
-interface CodeChunkHit {
+interface LocationHit {
+  _id: string;
   _source: {
+    chunk_id: string;
     filePath: string;
-    content: string;
     startLine: number;
     endLine: number;
-    kind: string;
   };
   sort: (string | number)[];
 }
@@ -40,57 +41,146 @@ interface ReconstructedChunk {
   kind: string;
 }
 
+const MISSING_CHUNK_ID_SAMPLE_SIZE = 5;
+
 /**
  * Reads the content of a file from the index, providing a reconstructed view
  * based on the most important indexed chunks. This function uses Elasticsearch's
  * `search_after` feature to paginate through all relevant chunks for the given file paths.
  *
  * @param {object} params - The parameters for the function.
- * @param {string[]} params.filePaths - An array of one or more absolute file paths to read.
+ * @param {string[]} params.filePaths - An array of one or more file paths (typically repository-relative) to read.
  * @returns {Promise<CallToolResult>} A promise that resolves to a CallToolResult containing the reconstructed file content,
  * formatted for the MCP server.
  */
 export async function readFile({ filePaths, index }: z.infer<typeof readFileSchema>): Promise<CallToolResult> {
-  const allHits: CodeChunkHit[] = [];
-  let searchAfter: (string | number)[] | undefined = undefined;
-
-  // The sort order is crucial for pagination and reconstruction
-  const sort: Sort = [
-    { filePath: 'asc' },
-    { startLine: 'asc' },
-    { endLine: 'desc' },
-    { updated_at: 'desc' },
-    { chunk_hash: 'asc' }, // Tie-breaker for consistent sorting
-  ];
-
   const { index: defaultIndex } = elasticsearchConfig;
+  const baseIndex = index || defaultIndex;
+  const locationsIndex = getLocationsIndexName(baseIndex);
 
   try {
-    while (true) {
-      const response = await client.search({
-        index: index || defaultIndex,
-        size: 1000, // Fetch in batches of 1000
-        _source: ['filePath', 'content', 'startLine', 'endLine', 'kind'],
-        query: {
-          bool: {
-            should: filePaths.map((filePath) => ({
-              match: { filePath },
-            })),
-            minimum_should_match: 1,
-          },
-        },
-        sort,
-        search_after: searchAfter,
-      });
+    const reconstructedFiles: { [filePath: string]: string } = {};
 
-      const hits = response.hits.hits as CodeChunkHit[];
-      if (hits.length === 0) {
-        break; // No more results, exit the loop
+    for (const requestedFilePath of filePaths) {
+      const allLocationsForFile: LocationHit[] = [];
+      let searchAfter: (string | number)[] | undefined = undefined;
+
+      const sort: Sort = [{ startLine: 'asc' }, { endLine: 'desc' }, { chunk_id: 'asc' }];
+
+      while (true) {
+        const response = await client.search({
+          index: locationsIndex,
+          size: 1000, // Fetch in batches of 1000
+          _source: ['chunk_id', 'filePath', 'startLine', 'endLine'],
+          query: {
+            term: { filePath: requestedFilePath },
+          },
+          sort,
+          search_after: searchAfter,
+        });
+
+        const hits = response.hits.hits as LocationHit[];
+        if (hits.length === 0) {
+          break; // No more results, exit the loop
+        }
+
+        allLocationsForFile.push(...hits);
+        searchAfter = hits[hits.length - 1].sort; // Get the sort values of the last document
       }
 
-      allHits.push(...hits);
-      searchAfter = hits[hits.length - 1].sort; // Get the sort values of the last document
+      if (allLocationsForFile.length === 0) {
+        reconstructedFiles[requestedFilePath] =
+          '// File not found in index.\n// No location documents found for this file path; the file may not be indexed or the path may be incorrect.';
+        continue;
+      }
+
+      const uniqueChunkIds = Array.from(
+        new Set(allLocationsForFile.map((h) => h._source.chunk_id).filter((id) => typeof id === 'string' && id.length))
+      );
+      const chunksById = await getChunksById(uniqueChunkIds, { index: baseIndex });
+      const missingChunkIds = uniqueChunkIds.filter((id) => !chunksById[id]);
+
+      const effectiveChunks = allLocationsForFile
+        .map((hit) => {
+          const chunk = chunksById[hit._source.chunk_id];
+          if (!chunk) return null;
+          return {
+            content: chunk.content,
+            kind: chunk.kind ?? 'chunk',
+            startLine: hit._source.startLine,
+            endLine: hit._source.endLine,
+            chunk_id: hit._source.chunk_id,
+          };
+        })
+        .filter(
+          (v): v is { content: string; kind: string; startLine: number; endLine: number; chunk_id: string } => v != null
+        );
+
+      effectiveChunks.sort((a, b) => {
+        if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+        if (a.endLine !== b.endLine) return b.endLine - a.endLine;
+        return a.chunk_id.localeCompare(b.chunk_id);
+      });
+
+      // With the sort order (startLine asc, endLine desc), we can do a simple
+      // filter to remove chunks that are completely contained within a previous one.
+      const dedupedChunks: ReconstructedChunk[] = [];
+      let lastEndLine = -1;
+
+      for (const chunk of effectiveChunks) {
+        if (chunk.endLine > lastEndLine) {
+          dedupedChunks.push({
+            content: chunk.content,
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            kind: chunk.kind,
+          });
+          lastEndLine = chunk.endLine;
+        }
+      }
+
+      let reconstructedContent = '';
+      let currentLine = 1;
+
+      if (missingChunkIds.length > 0) {
+        reconstructedContent += `// Warning: ${missingChunkIds.length} location(s) reference chunk_id(s) missing in the primary index.\n`;
+        reconstructedContent += `// Missing chunk_id sample: ${missingChunkIds.slice(0, MISSING_CHUNK_ID_SAMPLE_SIZE).join(', ')}\n\n`;
+      }
+
+      for (const chunk of dedupedChunks) {
+        const gap = chunk.startLine - currentLine;
+
+        if (reconstructedContent.length > 0) {
+          // Not the first chunk
+          if (gap > 0) {
+            reconstructedContent += `\n// (${gap} lines omitted)\n`;
+          } else if (gap === 0) {
+            reconstructedContent += '\n';
+          }
+          // if gap < 0, it's an overlap, we just append. The dedupe logic should handle this.
+        } else {
+          // First chunk
+          if (gap > 0) {
+            // file doesn't start at line 1
+            reconstructedContent += `// (${gap} lines omitted)\n`;
+          }
+        }
+
+        reconstructedContent += chunk.content;
+        currentLine = chunk.endLine + 1;
+      }
+
+      reconstructedFiles[requestedFilePath] = reconstructedContent;
     }
+
+    const content = Object.entries(reconstructedFiles).map(([filePath, fileContent]) => ({
+      type: 'text' as const,
+      text: `File: ${filePath}\n\n${fileContent}`,
+    }));
+
+    return {
+      content,
+    };
   } catch (error) {
     if (isIndexNotFoundError(error)) {
       const errorMessage = await formatIndexNotFoundError(index || defaultIndex);
@@ -101,73 +191,4 @@ export async function readFile({ filePaths, index }: z.infer<typeof readFileSche
     }
     throw error;
   }
-
-  // Group chunks by filePath
-  const chunksByFile = new Map<string, CodeChunkHit[]>();
-  for (const hit of allHits) {
-    const filePath = hit._source.filePath;
-    if (!chunksByFile.has(filePath)) {
-      chunksByFile.set(filePath, []);
-    }
-    chunksByFile.get(filePath)!.push(hit);
-  }
-
-  // Reconstruct each file
-  const reconstructedFiles: { [filePath: string]: string } = {};
-  for (const filePath of filePaths) {
-    const chunks = chunksByFile.get(filePath);
-
-    if (!chunks || chunks.length === 0) {
-      reconstructedFiles[filePath] = '// File not found in index... try a relative path.';
-      continue;
-    }
-
-    // With the new sort order (startLine asc, endLine desc), we can do a simple
-    // filter to remove chunks that are completely contained within a previous one.
-    const dedupedChunks: ReconstructedChunk[] = [];
-    let lastEndLine = -1;
-
-    for (const chunk of chunks) {
-      if (chunk._source.endLine > lastEndLine) {
-        dedupedChunks.push(chunk._source);
-        lastEndLine = chunk._source.endLine;
-      }
-    }
-
-    let reconstructedContent = '';
-    let currentLine = 1;
-
-    for (const chunk of dedupedChunks) {
-      const gap = chunk.startLine - currentLine;
-
-      if (reconstructedContent.length > 0) {
-        // Not the first chunk
-        if (gap > 0) {
-          reconstructedContent += `\n// (${gap} lines omitted)\n`;
-        } else if (gap === 0) {
-          reconstructedContent += '\n';
-        }
-        // if gap < 0, it's an overlap, we just append. The dedupe logic should handle this.
-      } else {
-        // First chunk
-        if (gap > 0) {
-          // file doesn't start at line 1
-          reconstructedContent += `// (${gap} lines omitted)\n`;
-        }
-      }
-
-      reconstructedContent += chunk.content;
-      currentLine = chunk.endLine + 1;
-    }
-    reconstructedFiles[filePath] = reconstructedContent;
-  }
-
-  const content = Object.entries(reconstructedFiles).map(([filePath, fileContent]) => ({
-    type: 'text' as const,
-    text: `File: ${filePath}\n\n${fileContent}`,
-  }));
-
-  return {
-    content,
-  };
 }

--- a/src/mcp_server/tools/semantic_code_search.md
+++ b/src/mcp_server/tools/semantic_code_search.md
@@ -175,3 +175,11 @@ semantic_code_search (entry point) → symbol_analysis (chain) → read_file_fro
 ```
 
 **Note**: Step 3 uses actual symbol names discovered in steps 1-2, NOT generic terms like "lens" or "embeddable".
+
+**Note (locations-first indices):** Chunk documents are content-deduplicated and do **not** store per-file metadata. File paths and line ranges are stored in the accompanying `<index>_locations` index and are joined by `chunk_id`.
+
+**Note (KQL across split storage):**
+- Chunk-level fields (e.g. `language`, `kind`, `content`) live in `<index>`.
+- File-level fields (e.g. `filePath`, `directoryPath`, `startLine`, `endLine`, `git_branch`) live in `<index>_locations`.
+- When you provide both `query` and `kql`, the tool evaluates `kql` across both stores (including `and/or/not`) against a bounded candidate set from the semantic query.
+- If you provide **only** `kql` and it references file-level fields, the tool will require adding a semantic `query` (to keep evaluation bounded).

--- a/src/mcp_server/tools/symbol_analysis.md
+++ b/src/mcp_server/tools/symbol_analysis.md
@@ -5,9 +5,19 @@ Precision tool for step 2 of "chain of investigation" - analyze specific symbols
 - **Architecture**: See definition, imports, call sites, tests, docs
 - **Impact**: Find all affected locations for changes
 
+## Notes (locations-first indices)
+
+Chunk documents in `<index>` are content-deduplicated and do **not** store `filePath`/line metadata. This tool uses `<index>_locations` to map chunk occurrences back to file paths.
+
 ## Workflow
 1. Find symbols via `semantic_code_search` or `map_symbols_by_query`
 2. Pass exact symbol name to `symbol_analysis` for complete connections
+
+Under the hood (high level):
+
+1. Search `<index>` for chunk candidates related to the symbol name (yields `chunk_id`s).
+2. Query `<index>_locations` to find which `filePath`s contain those `chunk_id`s (and gather a few example locations).
+3. Join back to `<index>` (multi-get by `chunk_id`) to enrich results with chunk-level metadata (language/type/kind/content).
 
 ## Parameters
 - `symbolName`: The name of the symbol to analyze.

--- a/src/mcp_server/tools/symbol_analysis.ts
+++ b/src/mcp_server/tools/symbol_analysis.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { fromKueryExpression, toElasticsearchQuery } from '../../../libs/es-query';
-import { client, isIndexNotFoundError, formatIndexNotFoundError } from '../../utils/elasticsearch'; // Assuming client is exported from here
+import {
+  client,
+  formatIndexNotFoundError,
+  getChunksById,
+  getLocationsIndexName,
+  isIndexNotFoundError,
+} from '../../utils/elasticsearch';
 import { elasticsearchConfig } from '../../config';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types';
 
@@ -66,29 +72,6 @@ export type SymbolAnalysisParams = z.infer<typeof symbolAnalysisSchema>;
  * @returns {Promise<CallToolResult>} A promise that resolves to a
  * `CallToolResult` object containing the symbol analysis report.
  */
-interface SymbolAggregation {
-  files: {
-    buckets: {
-      key: string;
-      languages: {
-        buckets: {
-          key: string;
-        }[];
-      };
-      kinds: {
-        buckets: {
-          key: string;
-          startLines: {
-            buckets: {
-              key: number;
-            }[];
-          };
-        }[];
-      };
-    }[];
-  };
-}
-
 /**
  * Analyzes a symbol and returns a report of its definitions, call sites, and references.
  *
@@ -101,47 +84,24 @@ interface SymbolAggregation {
  */
 export async function symbolAnalysis(params: SymbolAnalysisParams): Promise<CallToolResult> {
   const { symbolName, index } = params;
+  const baseIndex = index || elasticsearchConfig.index;
+  const locationsIndex = getLocationsIndexName(baseIndex);
   const kql = `content: "${symbolName}"`;
 
   const ast = fromKueryExpression(kql);
   const dsl = toElasticsearchQuery(ast);
 
   try {
-    const response = await client.search<unknown, SymbolAggregation>({
-      index: index || elasticsearchConfig.index,
+    const chunkHits = await client.search({
+      index: baseIndex,
       query: dsl,
-      aggs: {
-        files: {
-          terms: {
-            field: 'filePath',
-            size: 1000,
-          },
-          aggs: {
-            kinds: {
-              terms: {
-                field: 'kind',
-                size: 100,
-              },
-              aggs: {
-                startLines: {
-                  terms: {
-                    field: 'startLine',
-                    size: 100,
-                  },
-                },
-              },
-            },
-            languages: {
-              terms: {
-                field: 'language',
-                size: 10,
-              },
-            },
-          },
-        },
-      },
-      size: 0,
+      size: 5000,
+      _source: false,
     });
+
+    const chunkIds = chunkHits.hits.hits
+      .map((h) => h._id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
 
     const report: SymbolAnalysisReport = {
       primaryDefinitions: [],
@@ -151,47 +111,110 @@ export async function symbolAnalysis(params: SymbolAnalysisParams): Promise<Call
       documentation: [],
     };
 
-    if (response.aggregations) {
-      const files = response.aggregations;
-      for (const bucket of files.files.buckets) {
-        const filePath = bucket.key;
-        const languages = bucket.languages.buckets.map((b) => b.key);
-        const kinds: KindInfo[] = bucket.kinds.buckets.map((b) => ({
-          kind: b.key,
-          startLines: b.startLines.buckets.map((sl) => sl.key),
-        }));
+    if (chunkIds.length === 0) {
+      return { content: [{ type: 'text', text: JSON.stringify(report, null, 2) }] };
+    }
 
-        const fileInfo: FileInfo = {
-          filePath,
-          kinds,
-          languages,
+    const response = await client.search({
+      index: locationsIndex,
+      query: { terms: { chunk_id: chunkIds } },
+      size: 0,
+      aggs: {
+        files: {
+          terms: {
+            field: 'filePath',
+            size: 1000,
+          },
+          aggs: {
+            chunks: {
+              terms: {
+                field: 'chunk_id',
+                size: 2000,
+              },
+              aggs: {
+                startLine: {
+                  top_hits: {
+                    size: 1,
+                    _source: ['startLine'],
+                    sort: [{ startLine: { order: 'asc' } }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const buckets = (
+      response.aggregations as unknown as {
+        files?: {
+          buckets?: Array<{
+            key: string;
+            chunks?: {
+              buckets?: Array<{ key: string; startLine?: { hits?: { hits?: Array<{ _source?: unknown }> } } }>;
+            };
+          }>;
         };
+      }
+    )?.files?.buckets;
 
-        const allKinds = kinds.map((k) => k.kind);
+    const allChunkIds = Array.from(new Set((buckets ?? []).flatMap((b) => b.chunks?.buckets?.map((c) => c.key) ?? [])));
+    const chunksById = await getChunksById(allChunkIds, { index: baseIndex });
 
-        if (
-          allKinds.includes('function_declaration') ||
-          allKinds.includes('class_declaration') ||
-          allKinds.includes('lexical_declaration')
-        ) {
-          report.primaryDefinitions.push(fileInfo);
-        }
-        if (
-          allKinds.includes('interface_declaration') ||
-          allKinds.includes('type_alias_declaration') ||
-          allKinds.includes('enum_declaration')
-        ) {
-          report.typeDefinitions.push(fileInfo);
-        }
-        if (allKinds.includes('call_expression')) {
-          report.executionCallSites.push(fileInfo);
-        }
-        if (allKinds.includes('import_statement')) {
-          report.importReferences.push(fileInfo);
-        }
-        if (languages.includes('markdown') || allKinds.includes('comment')) {
-          report.documentation.push(fileInfo);
-        }
+    for (const bucket of buckets ?? []) {
+      const filePath = bucket.key;
+      const kindsByName: Record<string, number[]> = {};
+      const languagesSet = new Set<string>();
+
+      for (const c of bucket.chunks?.buckets ?? []) {
+        const chunk = chunksById[c.key];
+        if (!chunk) continue;
+        languagesSet.add(chunk.language);
+        const kind = chunk.kind ?? 'chunk';
+
+        const startLine = (c.startLine?.hits?.hits?.[0]?._source as { startLine?: unknown } | undefined)?.startLine;
+        const line = typeof startLine === 'number' ? startLine : 0;
+        if (!kindsByName[kind]) kindsByName[kind] = [];
+        kindsByName[kind].push(line);
+      }
+
+      const kinds: KindInfo[] = Object.entries(kindsByName).map(([kind, startLines]) => ({
+        kind,
+        startLines,
+      }));
+      const languages = Array.from(languagesSet);
+
+      const fileInfo: FileInfo = {
+        filePath,
+        kinds,
+        languages,
+      };
+
+      const allKinds = kinds.map((k) => k.kind);
+
+      if (
+        allKinds.includes('function_declaration') ||
+        allKinds.includes('class_declaration') ||
+        allKinds.includes('lexical_declaration')
+      ) {
+        report.primaryDefinitions.push(fileInfo);
+      }
+      if (
+        allKinds.includes('interface_declaration') ||
+        allKinds.includes('type_alias_declaration') ||
+        allKinds.includes('enum_declaration')
+      ) {
+        report.typeDefinitions.push(fileInfo);
+      }
+      if (allKinds.includes('call_expression')) {
+        report.executionCallSites.push(fileInfo);
+      }
+      if (allKinds.includes('import_statement')) {
+        report.importReferences.push(fileInfo);
+      }
+      if (languages.includes('markdown') || allKinds.includes('comment')) {
+        report.documentation.push(fileInfo);
       }
     }
 

--- a/src/utils/kql_chunk_id_filter.ts
+++ b/src/utils/kql_chunk_id_filter.ts
@@ -1,0 +1,189 @@
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { fromKueryExpression, toElasticsearchQuery } from '../../libs/es-query';
+import { KueryNode, getKqlFieldNames, nodeTypes } from '../../libs/es-query/src/kuery';
+import { client, getLocationsIndexName } from './elasticsearch';
+import { LOCATION_FIELDS } from './kql_scoping';
+
+function isLocationField(field: string): boolean {
+  return LOCATION_FIELDS.has(field);
+}
+
+function union(a: Set<string>, b: Set<string>): Set<string> {
+  if (a.size === 0) return new Set(b);
+  const out = new Set(a);
+  for (const v of b) out.add(v);
+  return out;
+}
+
+function intersect(a: Set<string>, b: Set<string>): Set<string> {
+  if (a.size === 0 || b.size === 0) return new Set();
+  const [small, big] = a.size <= b.size ? [a, b] : [b, a];
+  const out = new Set<string>();
+  for (const v of small) {
+    if (big.has(v)) out.add(v);
+  }
+  return out;
+}
+
+function difference(universe: Set<string>, remove: Set<string>): Set<string> {
+  if (universe.size === 0) return new Set();
+  if (remove.size === 0) return new Set(universe);
+  const out = new Set<string>();
+  for (const v of universe) {
+    if (!remove.has(v)) out.add(v);
+  }
+  return out;
+}
+
+const CHUNK_ID_BATCH_SIZE = 1000;
+
+function batchArray<T>(items: T[], batchSize: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    out.push(items.slice(i, i + batchSize));
+  }
+  return out;
+}
+
+function classifyLeafNode(node: KueryNode): 'chunk' | 'location' | 'unsupported_mixed' {
+  const fields = getKqlFieldNames(node);
+  const hasLocation = fields.some((f: string) => isLocationField(f));
+  const hasChunk = fields.some((f: string) => !isLocationField(f));
+
+  if (hasLocation && hasChunk) return 'unsupported_mixed';
+  if (hasLocation) return 'location';
+  return 'chunk';
+}
+
+async function matchChunkPredicateInUniverse(
+  dsl: QueryDslQueryContainer,
+  universeChunkIds: string[],
+  baseIndex: string
+): Promise<Set<string>> {
+  const matched = new Set<string>();
+  for (const batch of batchArray(universeChunkIds, CHUNK_ID_BATCH_SIZE)) {
+    const response = await client.search({
+      index: baseIndex,
+      query: {
+        bool: {
+          must: [dsl, { ids: { values: batch } }],
+        },
+      },
+      _source: false,
+      // We expect at most batch.length hits because the ids clause limits the set.
+      // Using size=batch.length avoids pagination while keeping the request bounded.
+      size: batch.length,
+    });
+
+    for (const hit of response.hits.hits) {
+      if (typeof hit._id === 'string' && hit._id.length > 0) {
+        matched.add(hit._id);
+      }
+    }
+  }
+  return matched;
+}
+
+async function matchLocationPredicateInUniverse(
+  dsl: QueryDslQueryContainer,
+  universeChunkIds: string[],
+  baseIndex: string
+): Promise<Set<string>> {
+  const matched = new Set<string>();
+  const locationsIndex = getLocationsIndexName(baseIndex);
+
+  for (const batch of batchArray(universeChunkIds, CHUNK_ID_BATCH_SIZE)) {
+    const response = await client.search({
+      index: locationsIndex,
+      query: {
+        bool: {
+          must: [dsl, { terms: { chunk_id: batch } }],
+        },
+      },
+      size: 0,
+      aggs: {
+        present: {
+          terms: {
+            field: 'chunk_id',
+            size: batch.length,
+          },
+        },
+      },
+    });
+
+    const buckets = (response.aggregations as unknown as { present?: { buckets?: Array<{ key?: unknown }> } })?.present
+      ?.buckets;
+    for (const b of buckets ?? []) {
+      if (typeof b.key === 'string') {
+        matched.add(b.key);
+      }
+    }
+  }
+
+  return matched;
+}
+
+async function evalNode(node: KueryNode, universe: Set<string>, baseIndex: string): Promise<Set<string>> {
+  if (nodeTypes.function.isNode(node)) {
+    if (node.function === 'and') {
+      const children = node.arguments as KueryNode[];
+      let acc = new Set(universe);
+      for (const child of children) {
+        acc = intersect(acc, await evalNode(child, universe, baseIndex));
+        if (acc.size === 0) break;
+      }
+      return acc;
+    }
+
+    if (node.function === 'or') {
+      const children = node.arguments as KueryNode[];
+      let acc = new Set<string>();
+      for (const child of children) {
+        acc = union(acc, await evalNode(child, universe, baseIndex));
+      }
+      return acc;
+    }
+
+    if (node.function === 'not') {
+      const [child] = node.arguments as KueryNode[];
+      if (!child) return new Set();
+      const childSet = await evalNode(child, universe, baseIndex);
+      return difference(universe, childSet);
+    }
+  }
+
+  // Leaf predicate: resolve by querying the correct index, but always restrict to the universe ids.
+  const universeIds = Array.from(universe);
+  if (universeIds.length === 0) return new Set();
+
+  const leafType = classifyLeafNode(node);
+  if (leafType === 'unsupported_mixed') {
+    const fields = Array.from(new Set((getKqlFieldNames(node) ?? []) as string[]));
+    const locationFields = fields.filter((f) => isLocationField(f));
+    const chunkFields = fields.filter((f) => !isLocationField(f));
+
+    throw new Error(
+      'Unsupported KQL expression: a single clause references both chunk fields and location fields. ' +
+        `Chunk fields: [${chunkFields.join(', ') || '<none>'}]. ` +
+        `Location fields: [${locationFields.join(', ') || '<none>'}]. ` +
+        'Please rewrite as separate clauses (e.g. (chunk_field:...) AND (location_field:...)) so it can be evaluated across <index> and <index>_locations.'
+    );
+  }
+
+  const dsl = toElasticsearchQuery(node);
+  return leafType === 'location'
+    ? await matchLocationPredicateInUniverse(dsl, universeIds, baseIndex)
+    : await matchChunkPredicateInUniverse(dsl, universeIds, baseIndex);
+}
+
+export async function filterChunkIdsByKqlWithinUniverse(options: {
+  kql: string;
+  baseIndex: string;
+  universeChunkIds: string[];
+}): Promise<Set<string>> {
+  const universe = new Set(options.universeChunkIds.filter((id) => typeof id === 'string' && id.length > 0));
+  if (universe.size === 0) return new Set();
+
+  const ast = fromKueryExpression(options.kql) as unknown as KueryNode;
+  return await evalNode(ast, universe, options.baseIndex);
+}

--- a/src/utils/kql_scoping.ts
+++ b/src/utils/kql_scoping.ts
@@ -1,0 +1,62 @@
+import { KueryNode, getKqlFieldNames, nodeBuilder, nodeTypes } from '../../libs/es-query/src/kuery';
+
+export const LOCATION_FIELDS = new Set([
+  'filePath',
+  'directoryPath',
+  'directoryName',
+  'directoryDepth',
+  'git_branch',
+  'git_file_hash',
+  'startLine',
+  'endLine',
+  'chunk_id',
+]);
+
+function classifyNode(node: KueryNode): 'chunk' | 'location' | 'mixed' {
+  const fields = getKqlFieldNames(node);
+  const hasLocation = fields.some((f: string) => LOCATION_FIELDS.has(f));
+  const hasChunk = fields.some((f: string) => !LOCATION_FIELDS.has(f));
+
+  if (hasLocation && hasChunk) return 'mixed';
+  if (hasLocation) return 'location';
+  return 'chunk';
+}
+
+export function splitKqlNodeByStorage(node: KueryNode): {
+  chunkNode?: KueryNode;
+  locationNode?: KueryNode;
+  hasMixed: boolean;
+} {
+  const classification = classifyNode(node);
+  if (classification === 'chunk') {
+    return { chunkNode: node, hasMixed: false };
+  }
+  if (classification === 'location') {
+    return { locationNode: node, hasMixed: false };
+  }
+
+  // Mixed: try to split `and(...)` safely; otherwise keep as location-only (to avoid ES errors).
+  if (nodeTypes.function.isNode(node) && node.function === 'and') {
+    const chunkChildren: KueryNode[] = [];
+    const locationChildren: KueryNode[] = [];
+    let hasMixed = false;
+
+    for (const child of node.arguments as KueryNode[]) {
+      const split = splitKqlNodeByStorage(child);
+      if (split.chunkNode) chunkChildren.push(split.chunkNode);
+      if (split.locationNode) locationChildren.push(split.locationNode);
+      if (split.hasMixed) hasMixed = true;
+      // Defensive: today splitKqlNodeByStorage always returns at least one node, but keep this guard
+      // in case the KQL AST shape changes or we add new node types.
+      if (!split.chunkNode && !split.locationNode) hasMixed = true;
+    }
+
+    return {
+      chunkNode: chunkChildren.length > 0 ? nodeBuilder.and(chunkChildren) : undefined,
+      locationNode: locationChildren.length > 0 ? nodeBuilder.and(locationChildren) : undefined,
+      hasMixed,
+    };
+  }
+
+  return { locationNode: node, hasMixed: true };
+}

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -1,0 +1,11 @@
+/**
+ * Centralized limits for query bounding and sampling.
+ *
+ * These values are intentionally conservative to keep Elasticsearch requests bounded.
+ */
+
+/**
+ * Maximum number of semantic candidates to scan when we must apply additional filtering (e.g. KQL)
+ * after semantic search. Semantic search is intended to be "top-K"; scanning too deep is expensive.
+ */
+export const MAX_SEMANTIC_SEARCH_CANDIDATES = 5000;

--- a/tests/mcp_server/document_symbols.test.ts
+++ b/tests/mcp_server/document_symbols.test.ts
@@ -38,11 +38,17 @@ describe('document_symbols', () => {
         {
           type: 'text',
           text: JSON.stringify({
-            [filePath]: [
-              { name: 'semanticCodeSearchSchema', kind: 'variable', line: 10 },
-              { name: 'semanticCodeSearch', kind: 'function', line: 20 },
-              { name: 'someOtherSymbol', kind: 'variable', line: 30 },
-            ],
+            [filePath]: {
+              symbols: {
+                variable: [
+                  { name: 'semanticCodeSearchSchema', line: 10 },
+                  { name: 'someOtherSymbol', line: 30 },
+                ],
+                function: [{ name: 'semanticCodeSearch', line: 20 }],
+              },
+              imports: {},
+              exports: {},
+            },
           }),
         },
       ],

--- a/tests/mcp_server/list_indices.test.ts
+++ b/tests/mcp_server/list_indices.test.ts
@@ -9,6 +9,7 @@ jest.mock('../../src/utils/elasticsearch', () => ({
     },
     search: jest.fn(),
   },
+  getLocationsIndexName: (index: string) => `${index}_locations`,
 }));
 
 jest.mock('../../src/config', () => ({
@@ -32,13 +33,17 @@ describe('listIndices', () => {
       'kibana-code-search-2.0': { aliases: { 'kibana-repo': {} } },
       'grafana-code-search': { aliases: { 'grafana-repo': {} } },
     });
-    (mockClient.search as jest.Mock).mockResolvedValue({
-      aggregations: {
-        filesIndexed: { value: 100 },
-        NumberOfSymbols: { total: { value: 200 } },
-        Languages: { buckets: [] },
-        Types: { buckets: [] },
-      },
+    (mockClient.search as jest.Mock).mockImplementation(({ index }: { index: string }) => {
+      if (index.endsWith('_locations')) {
+        return Promise.resolve({ aggregations: { filesIndexed: { value: 100 } } });
+      }
+      return Promise.resolve({
+        aggregations: {
+          NumberOfSymbols: { total: { value: 200 } },
+          Languages: { buckets: [] },
+          Types: { buckets: [] },
+        },
+      });
     });
 
     const result = await listIndices();
@@ -54,13 +59,17 @@ describe('listIndices', () => {
       'kibana-code-search-2.0': { aliases: { 'kibana-repo': {} } },
       'grafana-code-search': { aliases: { 'grafana-repo': {} } },
     });
-    (mockClient.search as jest.Mock).mockResolvedValue({
-      aggregations: {
-        filesIndexed: { value: 100 },
-        NumberOfSymbols: { total: { value: 200 } },
-        Languages: { buckets: [] },
-        Types: { buckets: [] },
-      },
+    (mockClient.search as jest.Mock).mockImplementation(({ index }: { index: string }) => {
+      if (index.endsWith('_locations')) {
+        return Promise.resolve({ aggregations: { filesIndexed: { value: 100 } } });
+      }
+      return Promise.resolve({
+        aggregations: {
+          NumberOfSymbols: { total: { value: 200 } },
+          Languages: { buckets: [] },
+          Types: { buckets: [] },
+        },
+      });
     });
 
     const result = await listIndices();

--- a/tests/mcp_server/read_file.test.ts
+++ b/tests/mcp_server/read_file.test.ts
@@ -1,0 +1,130 @@
+import { readFile } from '../../src/mcp_server/tools/read_file';
+import { client, isIndexNotFoundError, formatIndexNotFoundError } from '../../src/utils/elasticsearch';
+
+jest.mock('../../src/utils/elasticsearch', () => ({
+  client: {
+    search: jest.fn(),
+    indices: {
+      getAlias: jest.fn(),
+      exists: jest.fn(),
+    },
+    mget: jest.fn(),
+  },
+  elasticsearchConfig: {
+    index: 'test-index',
+  },
+  isIndexNotFoundError: jest.fn(),
+  formatIndexNotFoundError: jest.fn(),
+  getLocationsIndexName: (index: string) => `${index}_locations`,
+  getChunksById: jest.fn(),
+}));
+
+describe('read_file_from_chunks', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reconstruct using location docs joined to chunk docs', async () => {
+    const { getChunksById } = jest.requireMock('../../src/utils/elasticsearch') as { getChunksById: jest.Mock };
+    getChunksById.mockResolvedValue({
+      c1: { content: 'A', kind: 'function_declaration' },
+      c2: { content: 'B', kind: 'function_declaration' },
+    });
+
+    (client.search as jest.Mock).mockImplementation(
+      (req: { index?: string; query?: { term?: { filePath?: string } }; search_after?: unknown }) => {
+        if (req.index !== 'test-index_locations') {
+          return Promise.resolve({ hits: { hits: [] } });
+        }
+        const filePath = req.query?.term?.filePath;
+        if (req.search_after) {
+          return Promise.resolve({ hits: { hits: [] } });
+        }
+        if (filePath === 'file1.ts') {
+          return Promise.resolve({
+            hits: {
+              hits: [
+                { _id: 'l1', _source: { chunk_id: 'c1', filePath: 'file1.ts', startLine: 1, endLine: 1 }, sort: [1] },
+                { _id: 'l2', _source: { chunk_id: 'c2', filePath: 'file1.ts', startLine: 3, endLine: 3 }, sort: [3] },
+              ],
+            },
+          });
+        }
+        if (filePath === 'file2.ts') {
+          return Promise.resolve({
+            hits: {
+              hits: [
+                {
+                  _id: 'l3',
+                  _source: { chunk_id: 'c1', filePath: 'file2.ts', startLine: 50, endLine: 50 },
+                  sort: [50],
+                },
+                {
+                  _id: 'l4',
+                  _source: { chunk_id: 'c2', filePath: 'file2.ts', startLine: 52, endLine: 52 },
+                  sort: [52],
+                },
+              ],
+            },
+          });
+        }
+        return Promise.resolve({ hits: { hits: [] } });
+      }
+    );
+
+    const result = await readFile({ filePaths: ['file1.ts', 'file2.ts'] });
+
+    const findFileText = (prefix: string): string | undefined => {
+      const entry = result.content.find(
+        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.startsWith(prefix)
+      );
+      return entry?.type === 'text' && typeof entry.text === 'string' ? entry.text : undefined;
+    };
+
+    const file1Text = findFileText('File: file1.ts');
+    const file2Text = findFileText('File: file2.ts');
+
+    expect(file1Text).toContain('File: file1.ts');
+    expect(file1Text).toContain('A\n// (1 lines omitted)\nB');
+
+    expect(file2Text).toContain('File: file2.ts');
+    expect(file2Text).toContain('// (49 lines omitted)\nA\n// (1 lines omitted)\nB');
+  });
+
+  it('should return file not found message when no matching filePaths entry exists', async () => {
+    (client.search as jest.Mock)
+      .mockResolvedValueOnce({ hits: { hits: [] } })
+      .mockResolvedValueOnce({ hits: { hits: [] } });
+
+    const result = await readFile({ filePaths: ['missing.ts'] });
+    expect(result.content[0].text).toContain('File: missing.ts');
+    expect(result.content[0].text).toContain('File not found in index');
+  });
+
+  it('should return helpful error message when index is not found', async () => {
+    const indexNotFoundError = {
+      meta: {
+        body: {
+          error: {
+            type: 'index_not_found_exception',
+          },
+        },
+      },
+    };
+
+    (client.search as jest.Mock).mockReset().mockRejectedValue(indexNotFoundError);
+    (isIndexNotFoundError as jest.Mock).mockReturnValue(true);
+    (formatIndexNotFoundError as jest.Mock).mockResolvedValue(
+      "The index 'nonexistent-index' was not found.\n\nAvailable indices:\n- test-index (100 files)"
+    );
+
+    const result = await readFile({
+      filePaths: ['src/index.ts'],
+      index: 'nonexistent-index',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("The index 'nonexistent-index' was not found.");
+    expect(result.content[0].text).toContain('Available indices:');
+  });
+});

--- a/tests/mcp_server/symbol_analysis.test.ts
+++ b/tests/mcp_server/symbol_analysis.test.ts
@@ -4,10 +4,16 @@ import { client } from '../../src/utils/elasticsearch';
 jest.mock('../../src/utils/elasticsearch', () => ({
   client: {
     search: jest.fn(),
+    mget: jest.fn(),
+    indices: { exists: jest.fn() },
   },
   elasticsearchConfig: {
     index: 'semantic-code-search',
   },
+  getLocationsIndexName: (index: string) => `${index}_locations`,
+  getChunksById: jest.fn(),
+  isIndexNotFoundError: jest.fn(),
+  formatIndexNotFoundError: jest.fn(),
 }));
 
 describe('symbol_analysis', () => {
@@ -16,120 +22,73 @@ describe('symbol_analysis', () => {
   });
 
   it('should construct the correct Elasticsearch query and format the report', async () => {
-    (client.search as jest.Mock).mockResolvedValue({
-      aggregations: {
-        files: {
-          buckets: [
-            {
-              key: 'src/index.ts',
-              kinds: {
-                buckets: [
-                  {
-                    key: 'function_declaration',
-                    startLines: {
-                      buckets: [{ key: 10 }],
-                    },
-                  },
-                  {
-                    key: 'import_statement',
-                    startLines: {
-                      buckets: [{ key: 1 }],
-                    },
-                  },
-                ],
-              },
-              languages: {
-                buckets: [{ key: 'typescript' }],
-              },
-            },
-            {
-              key: 'README.md',
-              kinds: {
-                buckets: [],
-              },
-              languages: {
-                buckets: [{ key: 'markdown' }],
-              },
-            },
-          ],
+    (client.search as jest.Mock)
+      // chunk search
+      .mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: 'c1' }, { _id: 'c2' }, { _id: 'c3' }],
         },
-      },
+      })
+      // locations aggregation
+      .mockResolvedValueOnce({
+        aggregations: {
+          files: {
+            buckets: [
+              {
+                key: 'src/index.ts',
+                chunks: {
+                  buckets: [
+                    { key: 'c1', startLine: { hits: { hits: [{ _source: { startLine: 10 } }] } } },
+                    { key: 'c2', startLine: { hits: { hits: [{ _source: { startLine: 1 } }] } } },
+                  ],
+                },
+              },
+              {
+                key: 'README.md',
+                chunks: {
+                  buckets: [{ key: 'c3', startLine: { hits: { hits: [{ _source: { startLine: 1 } }] } } }],
+                },
+              },
+            ],
+          },
+        },
+      });
+
+    const { getChunksById } = jest.requireMock('../../src/utils/elasticsearch') as {
+      getChunksById: jest.Mock;
+    };
+    getChunksById.mockResolvedValue({
+      c1: { language: 'typescript', kind: 'function_declaration' },
+      c2: { language: 'typescript', kind: 'import_statement' },
+      c3: { language: 'markdown', kind: 'comment' },
     });
 
     const result = await symbolAnalysis({ symbolName: 'mySymbol' });
     const report = JSON.parse(result.content[0].text as string);
 
-    expect(client.search).toHaveBeenCalledWith({
-      index: 'semantic-code-search',
-      query: {
-        bool: {
-          minimum_should_match: 1,
-          should: [
-            {
-              match_phrase: {
-                content: 'mySymbol',
-              },
-            },
-          ],
-        },
-      },
-      aggs: {
-        files: {
-          terms: {
-            field: 'filePath',
-            size: 1000,
-          },
-          aggs: {
-            kinds: {
-              terms: {
-                field: 'kind',
-                size: 100,
-              },
-              aggs: {
-                startLines: {
-                  terms: {
-                    field: 'startLine',
-                    size: 100,
-                  },
-                },
-              },
-            },
-            languages: {
-              terms: {
-                field: 'language',
-                size: 10,
-              },
-            },
-          },
-        },
-      },
-      size: 0,
-    });
+    expect(client.search).toHaveBeenCalledTimes(2);
+    expect((client.search as jest.Mock).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        index: 'semantic-code-search',
+        size: 5000,
+        _source: false,
+      })
+    );
+    expect((client.search as jest.Mock).mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        index: 'semantic-code-search_locations',
+        size: 0,
+      })
+    );
 
     expect(report.primaryDefinitions).toHaveLength(1);
     expect(report.primaryDefinitions[0].filePath).toBe('src/index.ts');
-    expect(report.primaryDefinitions[0].kinds).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: 'function_declaration',
-          startLines: [10],
-        }),
-      ])
-    );
-    expect(report.importReferences).toHaveLength(1);
-    expect(report.importReferences[0].filePath).toBe('src/index.ts');
     expect(report.documentation).toHaveLength(1);
     expect(report.documentation[0].filePath).toBe('README.md');
   });
 
   it('should use the provided index when searching', async () => {
-    (client.search as jest.Mock).mockResolvedValue({
-      aggregations: {
-        files: {
-          buckets: [],
-        },
-      },
-    });
+    (client.search as jest.Mock).mockResolvedValueOnce({ hits: { hits: [] } });
 
     await symbolAnalysis({ symbolName: 'mySymbol', index: 'my-test-index' });
 


### PR DESCRIPTION
## Summary

This PR updates the MCP server to match the **locations-first** Elasticsearch storage model introduced in https://github.com/elastic/semantic-code-search-indexer/pull/135.

### Elasticsearch data model expected by this MCP server

Given a base index name `<index>`:

- `<index>`: **content-deduplicated chunk documents** (semantic search + chunk-level metadata)
- `<index>_locations`: **one document per chunk occurrence** (file path + line range + directory/git metadata) referencing the chunk by `chunk_id`

All file-level metadata is resolved from `<index>_locations` and joined back to `<index>` via `chunk_id` (typically using `mget`).

## Problem (with indexer #135)

[Indexer #135](https://github.com/elastic/semantic-code-search-indexer/pull/135) makes a deliberate breaking change: chunk documents in `<index>` no longer store file-level fields (e.g. `filePath`, `startLine`, `endLine`, aggregated file lists).

Without this PR:

- Tools that need file context (directory discovery, file reconstruction, filePath-filtered mapping) either fail outright or silently produce incomplete results.
- KQL that references file-level fields cannot be evaluated correctly if the MCP only queries `<index>`.

## Fix in this PR

This PR moves MCP’s file-level reads and KQL evaluation to the correct storage location (`<index>_locations`) while keeping chunk-level reads on `<index>`.

Key tool updates:

- `read_file_from_chunks`: reconstructs files by querying `<index>_locations` for `(filePath, startLine, endLine, chunk_id)` and then fetching chunk content via `mget` from `<index>`.
  - Adds a small warning header if `<index>_locations` references `chunk_id`s missing from `<index>` (visibility into partial-failure / eventual-consistency scenarios).
- `discover_directories`: discovers directories by aggregating on `<index>_locations.directoryPath` and enriching results using chunk docs from `<index>`.
- `map_symbols_by_query`: maps file → symbols/imports/exports by aggregating `filePath -> chunk_id` in `<index>_locations` and joining chunk docs from `<index>`.
- `symbol_analysis`: finds candidate chunk ids in `<index>`, then aggregates per-file presence via `<index>_locations`, then joins to chunk docs for enrichment.
- `semantic_code_search`:
  - Searches `<index>` (semantic_text) to get a bounded candidate set of `chunk_id`s.
  - Evaluates KQL with **correct boolean semantics** across the split model within that bounded set (supports `and/or/not`).
  - Returns chunk hits plus a sample of matching locations.
- `list_indices`: computes file counts via `<index>_locations` (cardinality of `filePath`).

## How it works (ASCII)

```text
read_file_from_chunks(filePaths[])
  -> search <index>_locations (filePath) => [(chunk_id, startLine, endLine)...]
  -> mget <index> (chunk_id) => chunk content
  -> sort + reconstruct

semantic_code_search(query, kql)
  -> search <index> (semantic_text [+ optional chunk-only KQL]) => candidate chunk_id[]
  -> evaluate full KQL across split storage within that universe:
     - chunk field clauses -> query <index> restricted to candidate ids
     - location field clauses -> query <index>_locations restricted to candidate ids
     - combine via set logic (and/or/not)
  -> fetch location samples from <index>_locations for resulting chunk_id[]
  -> return chunk hits + locations

map_symbols_by_query(kql)
  -> split KQL by storage (chunk vs location where possible)
  -> aggregate <index>_locations by filePath -> chunk_id (optionally restricted by chunk ids)
  -> mget <index> to enrich => grouped symbols/imports/exports per file
```

## Why this design (vs alternatives)

This PR is intentionally aligned to the indexer’s data model. The goal is **correct results at scale**, without reintroducing the behaviors that forced caps/timeouts in a single-index, location-aggregating design.

Alternatives considered:

1) **Keep MCP querying only `<index>` and “pretend” file metadata lives there**
- Rejected: file-level fields are not present on chunk docs in the locations-first model.

2) **Teach the indexer to denormalize file-level fields back onto `<index>` for MCP convenience**
- Rejected: that reintroduces the scaling failure mode (hot, growing chunk docs) that the locations-first model is explicitly avoiding.

3) **Only support `and`-style KQL splits and drop correct `or/not` semantics when location fields are involved**
- Rejected: it produces incorrect filtering semantics (surprising to users) and is hard to detect from the outside.

4) **Try to make `semantic_code_search` support unbounded KQL-only queries that reference `filePath`**
- Rejected: without a bounded candidate universe, this becomes “scan everything” behavior. It is both expensive and unpredictable at large scale.

## About complexity

This PR does add some complexity to MCP, but it’s the minimum necessary complexity imposed by the correct storage model:

- The MCP’s **user-facing tool behavior stays conceptually the same** (same inputs/outputs, same mental model: “search chunks, map them to files”).
- The additional complexity is **localized** to utilities that (a) split KQL by storage and (b) evaluate KQL across the two indices within a bounded candidate universe.
- The alternative to handling this complexity in MCP is to push it back into Elasticsearch document shape (denormalization / aggregation), which is exactly what breaks at scale.

In short: the MCP isn’t “getting fancy”; it’s querying the right source of truth and preserving correct semantics.

## Drawbacks / mitigations

- **Join required for some tools** (locations → `mget` chunks)
  - Mitigation: joins are batched (`mget`) and only done for the ids needed.
- **Temporary inconsistency possible** (locations reference a chunk that is missing)
  - Mitigation: `read_file_from_chunks` emits an explicit warning header to make this visible.
- **KQL-only queries with location fields are not allowed in `semantic_code_search`**
  - Mitigation: callers can add a semantic `query` to establish a bounded candidate set, or use tools that are naturally location-driven (`map_symbols_by_query`, `discover_directories`).

## Breaking

- MCP tools no longer expect `filePath` / aggregated file lists / per-file fields on chunk documents.

## Blocked

- Blocked by: `elastic/semantic-code-search-indexer#135` (requires a reindex using the new mapping/model)

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`