### PR TITLE
Align MCP server with alias-first indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ You must index your code base with the Semantic Code Search Indexer found here: 
 
 This MCP server expects the **locations-first** index model from indexer PR `elastic/semantic-code-search-indexer#135`:
 
-- `<index>` stores **content-deduplicated chunk documents** (semantic search + metadata).
-- `<index>_locations` stores **one document per chunk occurrence** (file path + line ranges + directory/git metadata) and references chunks by `chunk_id`.
+- `<alias>` stores **content-deduplicated chunk documents** (semantic search + metadata).
+- `<alias>_locations` stores **one document per chunk occurrence** (file path + line ranges + directory/git metadata) and references chunks by `chunk_id`.
 
-Several tools query `<index>_locations` and join back to `<index>` via `chunk_id` (typically using `mget`).
+Several tools query `<alias>_locations` and join back to `<alias>` via `chunk_id` (typically using `mget`).
+
+The indexer also maintains a stable settings index, `<alias>_settings`, for commit state and maintenance locking. This MCP server does not query `<alias>_settings` directly, but you should expect it to exist for any indexed alias.
 
 ## Running with Docker
 
@@ -92,7 +94,7 @@ For agents that connect over STDIO, you need to configure them to run the Docker
         "-i",
         "-e", "ELASTICSEARCH_CLOUD_ID=<your_cloud_id>",
         "-e", "ELASTICSEARCH_API_KEY=<your_api_key>",
-        "-e", "ELASTICSEARCH_INDEX=<your_index>",
+        "-e", "ELASTICSEARCH_INDEX=<your_alias>",
         "simianhacker/semantic-code-search-mcp-server",
         "node", "dist/src/mcp_server/bin.js", "stdio"
       ]
@@ -204,4 +206,4 @@ Configuration is managed via environment variables in a `.env` file.
 | --- | --- | --- |
 | `ELASTICSEARCH_CLOUD_ID` | The Cloud ID for your Elastic Cloud instance. | |
 | `ELASTICSEARCH_API_KEY` | An API key for Elasticsearch authentication. | |
-| `ELASTICSEARCH_INDEX` | The name of the Elasticsearch index to use. | `semantic-code-search` |
+| `ELASTICSEARCH_INDEX` | The **alias name** to query (stable public name). The MCP server will also query `<alias>_locations`. | `semantic-code-search` |

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.0
+    container_name: semantic-code-search-mcp-test-es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=true
+      - ELASTIC_PASSWORD=testpassword
+      - xpack.security.http.ssl.enabled=false
+      - xpack.ml.max_machine_memory_percent=90
+      - xpack.license.self_generated.type=trial
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -u elastic:testpassword -f http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - es-mcp-test-data:/usr/share/elasticsearch/data
+
+volumes:
+  es-mcp-test-data:
+    driver: local
+

--- a/docs/prompts/mcp-live-debug-harness.md
+++ b/docs/prompts/mcp-live-debug-harness.md
@@ -29,7 +29,7 @@ Crucially, the Harness will use a file watcher for live reloading. When a change
             "content": [
               {
                 "type": "text",
-                "text": "Index: beats-repo\n- Files: 10,460 total..."
+                "text": "Index: beats\n- Files: 10,460 total..."
               }
             ]
           },

--- a/docs/prompts/optimize-list_symbols_by_query-response.md
+++ b/docs/prompts/optimize-list_symbols_by_query-response.md
@@ -25,7 +25,7 @@ Output is a JSON object keyed by `filePath`. Each file contains grouped `symbols
 
 ### Note (locations-first indices)
 
-Per-file association is computed from `<index>_locations` (by aggregating `filePath` → `chunk_id`). Symbols/imports/exports are read from `<index>` and joined via `chunk_id`.
+Per-file association is computed from `<alias>_locations` (by aggregating `filePath` → `chunk_id`). Symbols/imports/exports are read from `<alias>` and joined via `chunk_id`.
 
 ## Historical Behavior (pre-grouped output)
 

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   watchman: false,
-  testMatch: ['**/tests/**/*.test.ts'],
-  testPathIgnorePatterns: ['<rootDir>/tests/integration/'],
+  testMatch: ['**/tests/integration/**/*.test.ts'],
   modulePathIgnorePatterns: ['<rootDir>/.repos/'],
+  testTimeout: 180000,
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "test": "jest",
+    "test:integration": "npm run test:integration:setup && npm run test:integration:run; TEST_EXIT_CODE=$?; npm run test:integration:teardown; exit $TEST_EXIT_CODE",
+    "test:integration:run": "jest --config jest.integration.config.js --runInBand",
+    "test:integration:setup": "bash scripts/setup-integration-tests.sh",
+    "test:integration:teardown": "bash scripts/teardown-integration-tests.sh",
     "prepare": "npm run build",
     "mcp-server": "ts-node src/mcp_server/bin.ts",
     "mcp-server:http": "ts-node src/mcp_server/bin.ts http"

--- a/scripts/setup-integration-tests.sh
+++ b/scripts/setup-integration-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+# Check for Docker Compose v2
+if ! docker compose version &> /dev/null; then
+  echo "ERROR: Docker Compose v2 not found."
+  echo "Please install Docker Desktop (Mac/Windows) or Docker Engine with Compose plugin (Linux)."
+  echo "See: https://docs.docker.com/compose/install/"
+  exit 1
+fi
+
+echo "Starting Elasticsearch for integration tests..."
+docker compose -f docker-compose.integration.yml up -d
+
+echo "Waiting for Elasticsearch to be ready..."
+timeout=180
+elapsed=0
+while ! curl -s -u elastic:testpassword -f http://localhost:9200/_cluster/health >/dev/null; do
+  if [ $elapsed -ge $timeout ]; then
+    echo "ERROR: Elasticsearch did not start within $timeout seconds"
+    docker compose -f docker-compose.integration.yml logs
+    exit 1
+  fi
+  echo "Waiting for Elasticsearch... ($elapsed/$timeout seconds)"
+  sleep 5
+  elapsed=$((elapsed + 5))
+done
+
+echo "Elasticsearch is ready!"
+echo ""
+echo "✅ Integration test environment is ready!"
+echo "   Elasticsearch: http://localhost:9200"
+echo "   Username: elastic"
+echo "   Password: testpassword"
+echo ""
+

--- a/scripts/teardown-integration-tests.sh
+++ b/scripts/teardown-integration-tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Check for Docker Compose v2
+if ! docker compose version &> /dev/null; then
+  echo "ERROR: Docker Compose v2 not found."
+  echo "Please install Docker Desktop (Mac/Windows) or Docker Engine with Compose plugin (Linux)."
+  exit 1
+fi
+
+echo "Stopping Elasticsearch integration test environment..."
+docker compose -f docker-compose.integration.yml down -v
+
+echo "✅ Integration test environment cleaned up!"
+

--- a/src/elasticsearch/directory_discovery.ts
+++ b/src/elasticsearch/directory_discovery.ts
@@ -26,7 +26,7 @@ interface DirectoryAggregationResponse {
 }
 
 /**
- * Discovers significant directories via `<index>_locations` (one document per chunk occurrence).
+ * Discovers significant directories via `<alias>_locations` (one document per chunk occurrence).
  */
 export async function discoverSignificantDirectories(
   client: Client,

--- a/src/mcp_server/prompts/chain_of_investigation.workflow.md
+++ b/src/mcp_server/prompts/chain_of_investigation.workflow.md
@@ -18,10 +18,10 @@
 
 This MCP server uses a locations-first Elasticsearch model:
 
-- Chunk-level fields (e.g. `language`, `kind`, `content`, `symbols`) live in `<index>`.
-- File-level fields (e.g. `filePath`, `directoryPath`, `startLine`, `endLine`) live in `<index>_locations`.
+- Chunk-level fields (e.g. `language`, `kind`, `content`, `symbols`) live in `<alias>`.
+- File-level fields (e.g. `filePath`, `directoryPath`, `startLine`, `endLine`) live in `<alias>_locations`.
 
-Implication: a KQL predicate like `filePath: *test*` is evaluated via `<index>_locations` and then joined back to `<index>` via `chunk_id`.
+Implication: a KQL predicate like `filePath: *test*` is evaluated via `<alias>_locations` and then joined back to `<alias>` via `chunk_id`.
 
 ### semantic_code_search
 **For discovering symbols**

--- a/src/mcp_server/tools/discover_directories.md
+++ b/src/mcp_server/tools/discover_directories.md
@@ -53,7 +53,7 @@ Returns a ranked list of directories with:
 - **Languages**: Programming languages used
 - **Score**: Average score of matches
 
-**Note (locations-first indices):** Directory and file-level information is derived from `<index>_locations` (one document per chunk occurrence). The tool may join to `<index>` via `chunk_id` to enrich results (e.g. languages / symbol counts).
+**Note (locations-first indices):** Directory and file-level information is derived from `<alias>_locations` (one document per chunk occurrence). The tool may join to `<alias>` via `chunk_id` to enrich results (e.g. languages / symbol counts).
 
 ## Example Output
 ```

--- a/src/mcp_server/tools/document_symbols.md
+++ b/src/mcp_server/tools/document_symbols.md
@@ -10,7 +10,7 @@ An AI coding agent can use this tool to get a focused list of symbols to documen
 
 ## Notes (locations-first indices)
 
-Per-file symbol listings are resolved via `<index>_locations` (mapping `filePath` → `chunk_id`) and then joined to `<index>` by `chunk_id` to read chunk-level symbol metadata.
+Per-file symbol listings are resolved via `<alias>_locations` (mapping `filePath` → `chunk_id`) and then joined to `<alias>` by `chunk_id` to read chunk-level symbol metadata.
 
 ## Parameters
 

--- a/src/mcp_server/tools/list_indices.md
+++ b/src/mcp_server/tools/list_indices.md
@@ -10,15 +10,15 @@ This tool allows LLMs to query for available indices and get a summary of their 
 
 This MCP server expects the locations-first model:
 
-- `<index>`: content-deduplicated chunk documents
-- `<index>_locations`: one document per chunk occurrence, including `filePath`
+- `<alias>`: content-deduplicated chunk documents
+- `<alias>_locations`: one document per chunk occurrence, including `filePath`
 
-For this tool, **file counts are computed from `<index>_locations`** using a `cardinality(filePath)` aggregation, because chunk documents do not store per-file metadata.
+For this tool, **file counts are computed from `<alias>_locations`** using a `cardinality(filePath)` aggregation, because chunk documents do not store per-file metadata.
 
 ## Output
 
 Returns a human-readable list of indices with:
 
-- Files: approximate count of unique file paths in `<index>_locations`
-- Symbols: approximate unique symbol count from `<index>` (nested `symbols`)
-- Languages / Content: rough breakdowns from `<index>`
+- Files: approximate count of unique file paths in `<alias>_locations`
+- Symbols: approximate unique symbol count from `<alias>` (nested `symbols`)
+- Languages / Content: rough breakdowns from `<alias>`

--- a/src/mcp_server/tools/list_indices.ts
+++ b/src/mcp_server/tools/list_indices.ts
@@ -25,10 +25,11 @@ interface Aggregations {
 
 export const listIndicesSchema = z.object({});
 
+const LOCATIONS_ALIAS_SUFFIX = '_locations';
+
 const aggregationQuery: SearchRequest = {
   size: 0,
   aggs: {
-    filesIndexed: { cardinality: { field: 'filePath' } },
     NumberOfSymbols: {
       nested: { path: 'symbols' },
       aggs: { total: { cardinality: { field: 'symbols.name' } } },
@@ -52,74 +53,118 @@ function formatNumber(num: number): string {
   return num.toString();
 }
 
+function getErrorStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const typedError = error as { meta?: { statusCode?: unknown } };
+  if (typedError.meta && typeof typedError.meta.statusCode === 'number') {
+    return typedError.meta.statusCode;
+  }
+
+  return undefined;
+}
+
 export async function listIndices(): Promise<CallToolResult> {
-  const aliasesResponse = await client.indices.getAlias({
-    name: '*-repo',
-  });
+  let aliasesResponse: Record<string, { aliases?: Record<string, unknown> }> = {};
+  try {
+    aliasesResponse = (await client.indices.getAlias({
+      name: `*${LOCATIONS_ALIAS_SUFFIX}`,
+    })) as unknown as Record<string, { aliases?: Record<string, unknown> }>;
+  } catch (error: unknown) {
+    // Elasticsearch returns 404 when no aliases match.
+    if (getErrorStatusCode(error) !== 404) {
+      throw error;
+    }
+  }
 
   if (!aliasesResponse || Object.keys(aliasesResponse).length === 0) {
     return {
-      content: [{ type: 'text', text: 'No indices found matching the "*-repo" pattern.' }],
+      content: [
+        {
+          type: 'text',
+          text:
+            'No semantic code search indices found.\n' +
+            `Expected to find aliases matching "*${LOCATIONS_ALIAS_SUFFIX}" (e.g. "<alias>${LOCATIONS_ALIAS_SUFFIX}") in Elasticsearch.`,
+        },
+      ],
     };
   }
 
   const defaultIndexName = elasticsearchConfig.index;
-  let result = '';
-  const indexEntries = Object.entries(aliasesResponse);
+  const blocks: string[] = [];
 
-  for (const [indexName, indexInfo] of indexEntries) {
+  const locationAliases = new Set<string>();
+  for (const [, indexInfo] of Object.entries(aliasesResponse)) {
     if (!indexInfo.aliases) continue;
-
-    const repoAliases = Object.keys(indexInfo.aliases).filter((alias) => alias.endsWith('-repo'));
-
-    for (const alias of repoAliases) {
-      const locationsIndex = getLocationsIndexName(alias);
-      const fileCountResponse = await client.search({
-        index: locationsIndex,
-        size: 0,
-        aggs: {
-          filesIndexed: { cardinality: { field: 'filePath' } },
-        },
-      });
-      const filesIndexedAgg = fileCountResponse.aggregations as { filesIndexed?: { value?: number } } | undefined;
-      const filesIndexed = filesIndexedAgg?.filesIndexed?.value ?? 0;
-
-      const searchResponse = await client.search<unknown, Omit<Aggregations, 'filesIndexed'>>({
-        index: alias,
-        ...aggregationQuery,
-      });
-
-      const aggregations = searchResponse.aggregations;
-
-      if (!aggregations) {
-        continue;
-      }
-
-      const numberOfSymbols = aggregations.NumberOfSymbols.total.value;
-      const languages = aggregations.Languages.buckets
-        .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.doc_count)} chunks)`)
-        .join(', ');
-      const types = aggregations.Types.buckets
-        .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.doc_count)} chunks)`)
-        .join(', ');
-
-      const isDefault = indexName === defaultIndexName || alias === defaultIndexName;
-      result += `Index: ${alias}${isDefault ? ' (Default)' : ''}\n`;
-      result += `- Files: ${filesIndexed.toLocaleString()} total\n`;
-      result += `- Symbols: ${numberOfSymbols.toLocaleString()} total\n`;
-      result += `- Languages: ${languages}\n`;
-      result += `- Content: ${types}\n`;
-
-      // Check if it's not the last alias of the last index entry
-      const isLastName = repoAliases.indexOf(alias) === repoAliases.length - 1;
-      const isLastEntry =
-        indexEntries.indexOf(indexEntries.find((entry) => entry[0] === indexName)!) === indexEntries.length - 1;
-
-      if (!isLastName || !isLastEntry) {
-        result += '---\n';
+    for (const alias of Object.keys(indexInfo.aliases)) {
+      if (alias.endsWith(LOCATIONS_ALIAS_SUFFIX)) {
+        locationAliases.add(alias);
       }
     }
   }
+
+  const baseAliases = Array.from(locationAliases)
+    .map((a) => a.slice(0, -LOCATIONS_ALIAS_SUFFIX.length))
+    .filter((a) => a.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+
+  for (const alias of baseAliases) {
+    const locationsIndex = getLocationsIndexName(alias);
+    const fileCountResponse = await client.search({
+      index: locationsIndex,
+      size: 0,
+      aggs: {
+        filesIndexed: { cardinality: { field: 'filePath' } },
+      },
+    });
+    const filesIndexedAgg = fileCountResponse.aggregations as { filesIndexed?: { value?: number } } | undefined;
+    const filesIndexed = filesIndexedAgg?.filesIndexed?.value ?? 0;
+
+    const searchResponse = await client.search<unknown, Omit<Aggregations, 'filesIndexed'>>({
+      index: alias,
+      ...aggregationQuery,
+    });
+
+    const aggregations = searchResponse.aggregations;
+
+    if (!aggregations) {
+      continue;
+    }
+
+    const numberOfSymbols = aggregations.NumberOfSymbols.total.value;
+    const languages = aggregations.Languages.buckets
+      .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.doc_count)} chunks)`)
+      .join(', ');
+    const types = aggregations.Types.buckets
+      .map((bucket: AggregationBucket) => `${bucket.key} (${formatNumber(bucket.doc_count)} chunks)`)
+      .join(', ');
+
+    const isDefault = alias === defaultIndexName;
+    blocks.push(
+      `Index: ${alias}${isDefault ? ' (Default)' : ''}\n` +
+        `- Files: ${filesIndexed.toLocaleString()} total\n` +
+        `- Symbols: ${numberOfSymbols.toLocaleString()} total\n` +
+        `- Languages: ${languages}\n` +
+        `- Content: ${types}\n`
+    );
+  }
+
+  if (blocks.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            'No semantic code search indices found (or accessible).\n' +
+            `Found aliases matching "*${LOCATIONS_ALIAS_SUFFIX}", but could not query expected aggregations.`,
+        },
+      ],
+    };
+  }
+
+  const result = blocks.join('---\n').trim();
   return {
     content: [{ type: 'text', text: result.trim() }],
   };

--- a/src/mcp_server/tools/map_symbols_by_query.md
+++ b/src/mcp_server/tools/map_symbols_by_query.md
@@ -20,10 +20,10 @@ Use the `kql` parameter for complex queries:
 
 This MCP server expects the locations-first model:
 
-- `<index>`: content-deduplicated chunk documents (symbols/imports/exports live here)
-- `<index>_locations`: one document per chunk occurrence (filePath/directoryPath live here)
+- `<alias>`: content-deduplicated chunk documents (symbols/imports/exports live here)
+- `<alias>_locations`: one document per chunk occurrence (filePath/directoryPath live here)
 
-When your KQL includes file-level fields (like `filePath`), those predicates are evaluated against `<index>_locations` and then joined back to `<index>` via `chunk_id`.
+When your KQL includes file-level fields (like `filePath`), those predicates are evaluated against `<alias>_locations` and then joined back to `<alias>` via `chunk_id`.
 
 ## Typical Workflow
 1. `discover_directories` → finds "src/platform/packages/kbn-esql-utils"

--- a/src/mcp_server/tools/read_file.md
+++ b/src/mcp_server/tools/read_file.md
@@ -35,4 +35,4 @@ process.exit(1)
 
 **Note:** The reconstruction is based on indexed code chunks. While it aims to be accurate, it may not be a perfect 1:1 representation of the original file. Requires the same `index` used in the initial `semantic_code_search` to maintain context.
 
-**Note (locations-first indices):** This tool reconstructs files by querying `<index>_locations` for `(filePath, startLine, endLine, chunk_id)` and then fetching the chunk text from the primary index via `chunk_id`.
+**Note (locations-first indices):** This tool reconstructs files by querying `<alias>_locations` for `(filePath, startLine, endLine, chunk_id)` and then fetching the chunk text from the primary index via `chunk_id`.

--- a/src/mcp_server/tools/semantic_code_search.md
+++ b/src/mcp_server/tools/semantic_code_search.md
@@ -176,10 +176,10 @@ semantic_code_search (entry point) → symbol_analysis (chain) → read_file_fro
 
 **Note**: Step 3 uses actual symbol names discovered in steps 1-2, NOT generic terms like "lens" or "embeddable".
 
-**Note (locations-first indices):** Chunk documents are content-deduplicated and do **not** store per-file metadata. File paths and line ranges are stored in the accompanying `<index>_locations` index and are joined by `chunk_id`.
+**Note (locations-first indices):** Chunk documents are content-deduplicated and do **not** store per-file metadata. File paths and line ranges are stored in the accompanying `<alias>_locations` index and are joined by `chunk_id`.
 
 **Note (KQL across split storage):**
-- Chunk-level fields (e.g. `language`, `kind`, `content`) live in `<index>`.
-- File-level fields (e.g. `filePath`, `directoryPath`, `startLine`, `endLine`, `git_branch`) live in `<index>_locations`.
+- Chunk-level fields (e.g. `language`, `kind`, `content`) live in `<alias>`.
+- File-level fields (e.g. `filePath`, `directoryPath`, `startLine`, `endLine`, `git_branch`) live in `<alias>_locations`.
 - When you provide both `query` and `kql`, the tool evaluates `kql` across both stores (including `and/or/not`) against a bounded candidate set from the semantic query.
 - If you provide **only** `kql` and it references file-level fields, the tool will require adding a semantic `query` (to keep evaluation bounded).

--- a/src/mcp_server/tools/semantic_code_search.ts
+++ b/src/mcp_server/tools/semantic_code_search.ts
@@ -47,7 +47,7 @@ export async function semanticCodeSearch(params: SemanticCodeSearchParams): Prom
 
   const baseIndex = index || elasticsearchConfig.index;
 
-  // Fast-path: KQL-only searches that reference only chunk fields can run directly on <index>.
+  // Fast-path: KQL-only searches that reference only chunk fields can run directly on <alias>.
   if (!query && kql) {
     // If KQL includes location fields and there's no semantic query to establish a bounded universe,
     // the split-index evaluation can become unbounded (especially with NOT). Require `query`.
@@ -57,7 +57,7 @@ export async function semanticCodeSearch(params: SemanticCodeSearchParams): Prom
     if (hasLocationField) {
       throw new Error(
         'KQL-only searches that reference file-level fields (e.g. filePath/directoryPath/startLine) require a semantic `query`.\n' +
-          'This MCP uses a split index model (<index> + <index>_locations) and needs a bounded candidate set to evaluate such filters safely.'
+          'This MCP uses a split index model (<alias> + <alias>_locations) and needs a bounded candidate set to evaluate such filters safely.'
       );
     }
   }
@@ -113,7 +113,7 @@ export async function semanticCodeSearch(params: SemanticCodeSearchParams): Prom
     const collected: Array<{ id: string; score: number; source: unknown }> = [];
 
     // Fetch semantic candidates in increasing batches until we can satisfy the requested page
-    // after applying KQL (which may require evaluating against <index>_locations).
+    // after applying KQL (which may require evaluating against <alias>_locations).
     const batchSize = Math.max(50, Math.min(500, size * 4));
     let from = 0;
 

--- a/src/mcp_server/tools/symbol_analysis.md
+++ b/src/mcp_server/tools/symbol_analysis.md
@@ -7,7 +7,7 @@ Precision tool for step 2 of "chain of investigation" - analyze specific symbols
 
 ## Notes (locations-first indices)
 
-Chunk documents in `<index>` are content-deduplicated and do **not** store `filePath`/line metadata. This tool uses `<index>_locations` to map chunk occurrences back to file paths.
+Chunk documents in `<alias>` are content-deduplicated and do **not** store `filePath`/line metadata. This tool uses `<alias>_locations` to map chunk occurrences back to file paths.
 
 ## Workflow
 1. Find symbols via `semantic_code_search` or `map_symbols_by_query`
@@ -15,9 +15,9 @@ Chunk documents in `<index>` are content-deduplicated and do **not** store `file
 
 Under the hood (high level):
 
-1. Search `<index>` for chunk candidates related to the symbol name (yields `chunk_id`s).
-2. Query `<index>_locations` to find which `filePath`s contain those `chunk_id`s (and gather a few example locations).
-3. Join back to `<index>` (multi-get by `chunk_id`) to enrich results with chunk-level metadata (language/type/kind/content).
+1. Search `<alias>` for chunk candidates related to the symbol name (yields `chunk_id`s).
+2. Query `<alias>_locations` to find which `filePath`s contain those `chunk_id`s (and gather a few example locations).
+3. Join back to `<alias>` (multi-get by `chunk_id`) to enrich results with chunk-level metadata (language/type/kind/content).
 
 ## Parameters
 - `symbolName`: The name of the symbol to analyze.

--- a/src/utils/kql_chunk_id_filter.ts
+++ b/src/utils/kql_chunk_id_filter.ts
@@ -166,7 +166,7 @@ async function evalNode(node: KueryNode, universe: Set<string>, baseIndex: strin
       'Unsupported KQL expression: a single clause references both chunk fields and location fields. ' +
         `Chunk fields: [${chunkFields.join(', ') || '<none>'}]. ` +
         `Location fields: [${locationFields.join(', ') || '<none>'}]. ` +
-        'Please rewrite as separate clauses (e.g. (chunk_field:...) AND (location_field:...)) so it can be evaluated across <index> and <index>_locations.'
+        'Please rewrite as separate clauses (e.g. (chunk_field:...) AND (location_field:...)) so it can be evaluated across <alias> and <alias>_locations.'
     );
   }
 

--- a/tests/integration/alias_first_architecture.integration.test.ts
+++ b/tests/integration/alias_first_architecture.integration.test.ts
@@ -1,0 +1,199 @@
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+
+describe('Integration Test - MCP alias-first contract (live Elasticsearch)', () => {
+  it('should list indices via *_locations aliases and reconstruct file content', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    const aliasName = `mcp-alias-first-${unique}`;
+    const backingIndex = `${aliasName}-scsi-${unique}`;
+    const backingLocationsIndex = `${backingIndex}_locations`;
+
+    process.env.ELASTICSEARCH_ENDPOINT = 'http://localhost:9200';
+    process.env.ELASTICSEARCH_USER = 'elastic';
+    process.env.ELASTICSEARCH_PASSWORD = 'testpassword';
+    process.env.ELASTICSEARCH_INDEX = aliasName;
+
+    jest.resetModules();
+
+    const { client } = await import('../../src/utils/elasticsearch');
+    const { listIndices } = await import('../../src/mcp_server/tools/list_indices');
+    const { readFile } = await import('../../src/mcp_server/tools/read_file');
+    const { mapSymbolsByQuery } = await import('../../src/mcp_server/tools/map_symbols_by_query');
+
+    const nowIso = () => new Date().toISOString();
+
+    const chunkMappings = {
+      properties: {
+        type: { type: 'keyword' },
+        language: { type: 'keyword' },
+        kind: { type: 'keyword' },
+        imports: {
+          type: 'nested',
+          properties: {
+            path: { type: 'keyword' },
+            type: { type: 'keyword' },
+            symbols: { type: 'keyword' },
+          },
+        },
+        symbols: {
+          type: 'nested',
+          properties: {
+            name: { type: 'keyword' },
+            kind: { type: 'keyword' },
+            line: { type: 'integer' },
+          },
+        },
+        exports: {
+          type: 'nested',
+          properties: {
+            name: { type: 'keyword' },
+            type: { type: 'keyword' },
+            target: { type: 'keyword' },
+          },
+        },
+        containerPath: { type: 'text' },
+        chunk_hash: { type: 'keyword' },
+        content: { type: 'text' },
+        semantic_text: { type: 'text' },
+        created_at: { type: 'date' },
+        updated_at: { type: 'date' },
+      },
+    } as const satisfies MappingTypeMapping;
+
+    const locationsMappings = {
+      properties: {
+        chunk_id: { type: 'keyword' },
+        filePath: { type: 'wildcard' },
+        startLine: { type: 'integer' },
+        endLine: { type: 'integer' },
+        directoryPath: { type: 'keyword', eager_global_ordinals: true },
+        directoryName: { type: 'keyword' },
+        directoryDepth: { type: 'integer' },
+        git_file_hash: { type: 'keyword' },
+        git_branch: { type: 'keyword' },
+        updated_at: { type: 'date' },
+      },
+    } as const satisfies MappingTypeMapping;
+
+    const chunk1Id = 'c1';
+    const chunk2Id = 'c2';
+    const filePath = 'src/file.ts';
+
+    try {
+      await client.indices.create({ index: backingIndex, mappings: chunkMappings });
+      await client.indices.create({ index: backingLocationsIndex, mappings: locationsMappings });
+
+      await client.indices.updateAliases({
+        actions: [
+          { add: { index: backingIndex, alias: aliasName } },
+          { add: { index: backingLocationsIndex, alias: `${aliasName}_locations` } },
+        ],
+      });
+
+      await client.index({
+        index: backingIndex,
+        id: chunk1Id,
+        document: {
+          type: 'code',
+          language: 'typescript',
+          kind: 'function_declaration',
+          imports: [{ path: 'react', type: 'module', symbols: ['useState'] }],
+          symbols: [{ name: 'Foo', kind: 'function_declaration', line: 1 }],
+          exports: [{ name: 'Foo', type: 'named' }],
+          containerPath: '',
+          chunk_hash: 'h1',
+          content: 'A',
+          semantic_text: 'A',
+          created_at: nowIso(),
+          updated_at: nowIso(),
+        },
+        refresh: true,
+      });
+
+      await client.index({
+        index: backingIndex,
+        id: chunk2Id,
+        document: {
+          type: 'code',
+          language: 'typescript',
+          kind: 'function_declaration',
+          symbols: [{ name: 'Bar', kind: 'function_declaration', line: 3 }],
+          exports: [{ name: 'Bar', type: 'named' }],
+          containerPath: '',
+          chunk_hash: 'h2',
+          content: 'B',
+          semantic_text: 'B',
+          created_at: nowIso(),
+          updated_at: nowIso(),
+        },
+        refresh: true,
+      });
+
+      await client.index({
+        index: backingLocationsIndex,
+        id: 'l1',
+        document: {
+          chunk_id: chunk1Id,
+          filePath,
+          startLine: 1,
+          endLine: 1,
+          directoryPath: 'src',
+          directoryName: 'src',
+          directoryDepth: 1,
+          git_branch: 'main',
+          updated_at: nowIso(),
+        },
+        refresh: true,
+      });
+
+      await client.index({
+        index: backingLocationsIndex,
+        id: 'l2',
+        document: {
+          chunk_id: chunk2Id,
+          filePath,
+          startLine: 3,
+          endLine: 3,
+          directoryPath: 'src',
+          directoryName: 'src',
+          directoryDepth: 1,
+          git_branch: 'main',
+          updated_at: nowIso(),
+        },
+        refresh: true,
+      });
+
+      // 1) list_indices discovers via *_locations aliases (no -repo assumptions).
+      const listResult = await listIndices();
+      const listText = listResult.content[0]?.type === 'text' ? listResult.content[0].text : '';
+      expect(listText).toContain(`Index: ${aliasName} (Default)`);
+      expect(listText).toContain('- Files: 1 total');
+
+      // 2) read_file_from_chunks joins <alias>_locations -> <alias>.
+      const readResult = await readFile({ filePaths: [filePath] });
+      const fileText = readResult.content[0]?.type === 'text' ? readResult.content[0].text : '';
+      expect(fileText).toContain(`File: ${filePath}`);
+      expect(fileText).toContain('A\n// (1 lines omitted)\nB');
+
+      // 3) map_symbols_by_query joins chunk ids to symbols.
+      const mapResult = await mapSymbolsByQuery({ kql: `filePath: ${filePath}`, size: 1000 });
+      expect(mapResult.content[0]?.type).toBe('text');
+      const parsed = JSON.parse((mapResult.content[0] as { type: 'text'; text: string }).text) as Record<
+        string,
+        unknown
+      >;
+      expect(Object.keys(parsed)).toContain(filePath);
+    } finally {
+      // Best-effort cleanup.
+      try {
+        await client.indices.delete({ index: backingLocationsIndex });
+      } catch {
+        // ignore
+      }
+      try {
+        await client.indices.delete({ index: backingIndex });
+      } catch {
+        // ignore
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #35

Sibling PR (Indexer): https://github.com/elastic/semantic-code-search-indexer/pull/149

## Summary
- Treat `ELASTICSEARCH_INDEX` as a stable alias name.
- Discover available indices via `*_locations` aliases (no `*-repo` assumptions).
- Add an integration test that asserts the alias-first contract against a live Elasticsearch.

## Model (locations-first + alias-first)

```
<alias>_locations  (file-level docs: filePath/startLine/...)  --(chunk_id)-->  <alias>  (chunk docs)
```

## Test Plan
- `npm run lint` (pass)
- `npm run build` (pass)
- `npm test` (pass)
- `npm run test:integration` (pass)

Made with [Cursor](https://cursor.com)