### PR TITLE
feat: Oauth2 authorization server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,33 @@ ELASTICSEARCH_USER=
 ELASTICSEARCH_PASSWORD=
 ELASTICSEARCH_API_KEY=
 ELASTICSEARCH_INDEX=semantic-code-search
+
+# --- Optional: OAuth/OIDC (HTTP transport only) ---
+# When disabled, the server behaves exactly as before (no auth on /mcp).
+OIDC_AUTH_ENABLED=false
+
+# Public base URL of this MCP server (behind your load balancer).
+# Used for OAuth discovery documents and as JWT issuer/audience.
+OAUTH_SERVER_URL=http://localhost:3000
+
+# Secret used to sign the MCP access tokens (HS256). Must be stable across restarts/instances.
+JWT_SIGNING_SECRET=REPLACE_WITH_STRONG_RANDOM_SECRET
+
+# Upstream OIDC provider configuration (Okta, Google, Auth0, Keycloak, ...)
+OIDC_ISSUER=https://YOUR_OIDC_ISSUER
+OIDC_CLIENT_ID=YOUR_OIDC_CLIENT_ID
+OIDC_CLIENT_SECRET=YOUR_OIDC_CLIENT_SECRET
+
+# Secret used to sign state + cookies. Must be stable across restarts/instances.
+OIDC_COOKIE_SECRET=REPLACE_WITH_STRONG_RANDOM_SECRET
+
+# Comma-separated required claims (default: sub)
+OIDC_REQUIRED_CLAIMS=sub,email
+
+# Storage backend for OAuth server state (refresh tokens, auth codes, sessions).
+# Use redis for production / load balancer deployments.
+OAUTH_STORAGE=memory
+REDIS_URL=redis://localhost:6379
+
+# Debug helpers (default: false). Enables /oauth/debug and safe auth logs.
+OAUTH_DEBUG_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  redis:
+    image: redis:8-trixie
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  redisinsight:
+    image: redis/redisinsight:latest
+    ports:
+      - "5540:5540"
+    depends_on:
+      redis:
+        condition: service_healthy
+
+volumes:
+  redis-data:

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   testEnvironment: 'node',
   watchman: false,
   testMatch: ['**/tests/**/*.test.ts'],
-  modulePathIgnorePatterns: ['<rootDir>/.repos/'],
+  modulePathIgnorePatterns: ['<rootDir>/.repos/', '<rootDir>/github-mcp-server/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,12 @@
         "@types/moment-timezone": "^0.5.13",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "ioredis": "^5.9.3",
+        "jose": "^6.1.3",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
-        "moment-timezone": "^0.6.0"
+        "moment-timezone": "^0.6.0",
+        "openid-client": "^6.8.2"
       },
       "bin": {
         "mcp-server": "dist/src/mcp_server/bin.js"
@@ -27,6 +30,7 @@
       "devDependencies": {
         "@types/jest": "30.0.0",
         "@types/node": "24.3.0",
+        "@types/supertest": "^7.2.0",
         "@typescript-eslint/eslint-plugin": "8.40.0",
         "@typescript-eslint/parser": "8.40.0",
         "dotenv-cli": "10.0.0",
@@ -37,6 +41,7 @@
         "jest": "30.1.1",
         "peggy": "5.0.6",
         "prettier": "3.6.2",
+        "supertest": "^7.2.2",
         "ts-jest": "29.4.1",
         "ts-node": "10.9.2",
         "typescript": "5.9.2",
@@ -889,6 +894,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1572,6 +1583,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1641,6 +1665,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@peggyjs/from-mem": {
@@ -1831,6 +1865,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1918,6 +1959,13 @@
       "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1988,6 +2036,30 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2724,6 +2796,20 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "30.1.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.1.tgz",
@@ -3157,6 +3243,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3192,6 +3287,19 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/command-line-args": {
       "version": "6.0.1",
@@ -3239,6 +3347,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-map": {
@@ -3293,6 +3411,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -3377,6 +3502,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3394,6 +3538,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -3568,6 +3723,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4069,6 +4240,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4208,6 +4386,64 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4421,6 +4657,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4586,6 +4838,30 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
+      "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5523,6 +5799,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5673,6 +5958,18 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5767,6 +6064,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5779,6 +6086,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -5948,6 +6268,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6004,6 +6333,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.2.tgz",
+      "integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.1.3",
+        "oauth4webapi": "^3.8.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -6385,9 +6727,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6450,6 +6792,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6820,6 +7183,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7001,6 +7370,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "test": "jest",
     "prepare": "npm run build",
-    "mcp-server": "ts-node src/mcp_server/bin.ts",
-    "mcp-server:http": "ts-node src/mcp_server/bin.ts http"
+    "mcp-server": "ts-node --files src/mcp_server/bin.ts",
+    "mcp-server:http": "ts-node --files src/mcp_server/bin.ts http"
   },
   "keywords": [],
   "author": "",
@@ -30,13 +30,17 @@
     "@types/moment-timezone": "^0.5.13",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "ioredis": "^5.9.3",
+    "jose": "^6.1.3",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "moment-timezone": "^0.6.0"
+    "moment-timezone": "^0.6.0",
+    "openid-client": "^6.8.2"
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
     "@types/node": "24.3.0",
+    "@types/supertest": "^7.2.0",
     "@typescript-eslint/eslint-plugin": "8.40.0",
     "@typescript-eslint/parser": "8.40.0",
     "dotenv-cli": "10.0.0",
@@ -47,6 +51,7 @@
     "jest": "30.1.1",
     "peggy": "5.0.6",
     "prettier": "3.6.2",
+    "supertest": "^7.2.2",
     "ts-jest": "29.4.1",
     "ts-node": "10.9.2",
     "typescript": "5.9.2",

--- a/src/auth/cookies.ts
+++ b/src/auth/cookies.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal cookie parsing/serialization for the OAuth/OIDC browser flow.
+ *
+ * Used by `/oauth/authorize` + `/oauth/callback` to persist the user session id and remembered client
+ * approvals in HttpOnly cookies (without pulling in an additional cookie parsing dependency).
+ */
+import type { Request } from 'express';
+
+export const parseCookies = (req: Request) => {
+  const header = req.headers.cookie;
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  const parts = header.split(';');
+  for (const part of parts) {
+    const [k, ...rest] = part.trim().split('=');
+    if (!k) continue;
+    out[k] = decodeURIComponent(rest.join('=') || '');
+  }
+  return out;
+};
+
+export const serializeCookie = (
+  name: string,
+  value: string,
+  opts: {
+    httpOnly?: boolean;
+    secure?: boolean;
+    sameSite?: 'Lax' | 'Strict' | 'None';
+    path?: string;
+    maxAgeSeconds?: number;
+  }
+) => {
+  const segments: string[] = [];
+  segments.push(`${name}=${encodeURIComponent(value)}`);
+  segments.push(`Path=${opts.path ?? '/'}`);
+  if (opts.httpOnly) segments.push('HttpOnly');
+  if (opts.secure) segments.push('Secure');
+  if (opts.sameSite) segments.push(`SameSite=${opts.sameSite}`);
+  if (opts.maxAgeSeconds != null) segments.push(`Max-Age=${Math.floor(opts.maxAgeSeconds)}`);
+  return segments.join('; ');
+};

--- a/src/auth/crypto.ts
+++ b/src/auth/crypto.ts
@@ -1,0 +1,62 @@
+/**
+ * Crypto primitives used throughout the OAuth/OIDC flow.
+ *
+ * Provides base64url encoding, HMAC signing for state/cookies, token generation, timing-safe compares,
+ * and encryption for storing upstream refresh tokens at rest (in session storage).
+ */
+import crypto from 'crypto';
+
+export const base64url = {
+  encode: (buf: Uint8Array | Buffer | string) => {
+    const b = typeof buf === 'string' ? Buffer.from(buf, 'utf8') : Buffer.from(buf);
+    return b.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  },
+  decode: (str: string) => {
+    const pad = str.length % 4 === 0 ? '' : '='.repeat(4 - (str.length % 4));
+    const s = str.replace(/-/g, '+').replace(/_/g, '/') + pad;
+    return Buffer.from(s, 'base64');
+  },
+};
+
+export const hmacSha256Hex = (secret: string, data: string) => {
+  return crypto.createHmac('sha256', secret).update(data).digest('hex');
+};
+
+export const sha256Base64url = (data: string) => {
+  const digest = crypto.createHash('sha256').update(data).digest();
+  return base64url.encode(digest);
+};
+
+export const randomToken = (bytes = 32) => {
+  return base64url.encode(crypto.randomBytes(bytes));
+};
+
+export const timingSafeEqualStr = (a: string, b: string) => {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+};
+
+export const derive32ByteKey = (secret: string) => {
+  return crypto.createHash('sha256').update(secret).digest(); // 32 bytes
+};
+
+export const encryptAes256Gcm = (key32: Buffer, plaintext: string) => {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key32, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return base64url.encode(Buffer.concat([iv, tag, ciphertext]));
+};
+
+export const decryptAes256Gcm = (key32: Buffer, enc: string) => {
+  const raw = base64url.decode(enc);
+  const iv = raw.subarray(0, 12);
+  const tag = raw.subarray(12, 28);
+  const ciphertext = raw.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key32, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+};

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,0 +1,64 @@
+/**
+ * Bearer-token auth middleware for protecting the MCP endpoint.
+ *
+ * Validates access tokens minted by our `/oauth/token` endpoint and attaches claims onto the request
+ * so MCP handlers/tools can enforce authorization and required OIDC claims.
+ */
+import type { NextFunction, Request, Response } from 'express';
+
+import type { OAuthConfig } from '../config';
+import { runWithAuthClaims } from './request_context';
+import { verifyAccessToken } from './tokens';
+
+const wwwAuthenticate = (cfg: OAuthConfig, extras?: Record<string, string>) => {
+  const params: Record<string, string> = {
+    // Point clients at MCP-specific Protected Resource Metadata.
+    resource_metadata: `${cfg.oauthServerUrl}/.well-known/oauth-protected-resource/mcp`,
+    ...(extras ?? {}),
+  };
+  const parts = Object.entries(params).map(([k, v]) => `${k}="${v.replace(/"/g, '')}"`);
+  return `Bearer ${parts.join(', ')}`;
+};
+
+export const bearerAuth = (cfg: OAuthConfig) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const header = req.headers.authorization;
+    if (!header || !header.toLowerCase().startsWith('bearer ')) {
+      res.setHeader('WWW-Authenticate', wwwAuthenticate(cfg));
+      res.status(401).send('Unauthorized');
+      return;
+    }
+
+    const token = header.slice('bearer '.length).trim();
+    try {
+      const claims = await verifyAccessToken({
+        token,
+        signingSecret: cfg.jwtSigningSecret,
+        issuer: cfg.oauthServerUrl,
+        audience: cfg.oauthServerUrl,
+      });
+
+      for (const claim of cfg.oidcRequiredClaims) {
+        if ((claims as unknown as Record<string, unknown>)[claim] == null) {
+          res.status(403).send('Forbidden');
+          return;
+        }
+      }
+
+      req.mcpAuth = { claims };
+
+      if (cfg.debugEnabled) {
+        const now = Math.floor(Date.now() / 1000);
+        const exp = typeof claims.exp === 'number' ? claims.exp : undefined;
+        const remaining = exp ? Math.max(0, exp - now) : null;
+        // Safe, derived logging only: never log raw tokens or headers.
+        console.log(`[oauth-debug] path=${req.path} sub=${claims.sub} scope=${claims.scope} expires_in=${remaining}`);
+      }
+
+      return runWithAuthClaims(claims, () => next());
+    } catch {
+      res.setHeader('WWW-Authenticate', wwwAuthenticate(cfg, { error: 'invalid_token' }));
+      res.status(401).send('Unauthorized');
+    }
+  };
+};

--- a/src/auth/oidc.ts
+++ b/src/auth/oidc.ts
@@ -1,0 +1,29 @@
+/**
+ * Upstream OIDC client discovery and configuration caching.
+ *
+ * Our OAuth server delegates user authentication to an external OIDC provider; this module performs
+ * discovery and caches the resulting client configuration so `/oauth/authorize` and `/oauth/callback`
+ * can drive the upstream login flow.
+ */
+import type { OAuthConfig } from '../config';
+import type { Configuration } from 'openid-client';
+
+export type OidcClientBundle = {
+  config: Configuration;
+  redirectUri: string;
+};
+
+let cached: { issuer: string; bundle: OidcClientBundle } | null = null;
+
+export const getOidcClient = async (cfg: OAuthConfig): Promise<OidcClientBundle> => {
+  if (cached && cached.issuer === cfg.oidcIssuer) return cached.bundle;
+
+  const redirectUri = `${cfg.oauthServerUrl}/oauth/callback`;
+  // openid-client v6: functional API, discovery returns a Configuration object.
+  const oidc = (await import('openid-client')) as typeof import('openid-client');
+  const config = await oidc.discovery(new URL(cfg.oidcIssuer), cfg.oidcClientId, cfg.oidcClientSecret);
+
+  const bundle = { config, redirectUri };
+  cached = { issuer: cfg.oidcIssuer, bundle };
+  return bundle;
+};

--- a/src/auth/pkce.ts
+++ b/src/auth/pkce.ts
@@ -1,0 +1,12 @@
+/**
+ * PKCE verification for the OAuth authorization code flow.
+ *
+ * The `/oauth/token` endpoint verifies `code_verifier` against the stored `code_challenge` before
+ * minting access/refresh tokens.
+ */
+import { sha256Base64url } from './crypto';
+
+export const verifyPkceS256 = (codeVerifier: string, codeChallenge: string) => {
+  const computed = sha256Base64url(codeVerifier);
+  return computed === codeChallenge;
+};

--- a/src/auth/request_context.ts
+++ b/src/auth/request_context.ts
@@ -1,0 +1,24 @@
+/**
+ * Per-request auth claims context.
+ *
+ * After bearer token validation, claims are stored in AsyncLocalStorage so lower-level code (tools,
+ * storage, request handlers) can read the current subject/claims without threading parameters through
+ * every call.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { AccessTokenClaims } from './tokens';
+
+type Store = {
+  claims: AccessTokenClaims;
+};
+
+const als = new AsyncLocalStorage<Store>();
+
+export const runWithAuthClaims = <T>(claims: AccessTokenClaims, fn: () => T) => {
+  return als.run({ claims }, fn);
+};
+
+export const getAuthClaims = () => {
+  return als.getStore()?.claims;
+};

--- a/src/auth/router.ts
+++ b/src/auth/router.ts
@@ -1,0 +1,29 @@
+/**
+ * OAuth router composition.
+ *
+ * Mounts all OAuth/OIDC-related endpoints (well-known metadata, dynamic client registration,
+ * authorization, token exchange, and optional debug endpoints) onto a single Express router.
+ */
+import express from 'express';
+
+import type { OAuthConfig } from '../config';
+import type { OAuthStorage } from './storage';
+import { registerAuthorizeRoutes } from './routes/authorize';
+import { registerDebugRoutes } from './routes/debug';
+import { registerDcrRoutes } from './routes/register';
+import { registerTokenRoutes } from './routes/token';
+import { registerWellKnownRoutes } from './routes/well_known';
+
+export const createOAuthRouter = (cfg: OAuthConfig, storage: OAuthStorage) => {
+  const router = express.Router();
+
+  registerWellKnownRoutes(router, cfg);
+  registerDcrRoutes(router, cfg, storage);
+  registerAuthorizeRoutes(router, cfg, storage);
+  registerTokenRoutes(router, cfg, storage);
+  if (cfg.debugEnabled) {
+    registerDebugRoutes(router, cfg);
+  }
+
+  return router;
+};

--- a/src/auth/routes/authorize.ts
+++ b/src/auth/routes/authorize.ts
@@ -1,0 +1,452 @@
+/**
+ * OAuth Authorization Endpoint (+ upstream OIDC login + consent UI).
+ *
+ * Handles `/oauth/authorize` requests from MCP clients, ensures the user is authenticated via an
+ * external OIDC provider, records consent, and issues short-lived authorization codes to be exchanged
+ * at `/oauth/token`.
+ */
+import { randomUUID } from 'crypto';
+import type { Request, Response, Router } from 'express';
+
+import type { OAuthConfig } from '../../config';
+import { derive32ByteKey, encryptAes256Gcm, randomToken } from '../crypto';
+import { parseCookies, serializeCookie } from '../cookies';
+import { signState, verifyState } from '../state';
+import type { OAuthStorage } from '../storage';
+import { getOidcClient } from '../oidc';
+
+const getOidc = async () => (await import('openid-client')) as typeof import('openid-client');
+
+type ClientOAuthRequest = {
+  response_type: string;
+  client_id: string;
+  redirect_uri: string;
+  scope?: string;
+  state?: string;
+  code_challenge: string;
+  code_challenge_method?: string;
+  resource?: string;
+};
+
+type OidcStatePayload = {
+  txId: string;
+  oauth: ClientOAuthRequest;
+};
+
+type ConsentStatePayload = {
+  oauth: ClientOAuthRequest;
+};
+
+type SessionCookiePayload = {
+  sessionId: string;
+};
+
+type ApprovalCookiePayload = {
+  approvedClientIds: string[];
+};
+
+const SESSION_COOKIE = 'scsi_session';
+const APPROVAL_COOKIE = 'mcp-approved-clients';
+
+const AUTH_CODE_TTL_MS = 10 * 60 * 1000;
+const OIDC_STATE_TTL_SECONDS = 10 * 60;
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+const APPROVAL_TTL_SECONDS = 365 * 24 * 60 * 60;
+
+const setNoCORS = (res: Response) => {
+  // Intentional: do not reflect Origin on OAuth endpoints.
+  res.removeHeader('Access-Control-Allow-Origin');
+};
+
+const isHttps = (cfg: OAuthConfig) => cfg.oauthServerUrl.startsWith('https://');
+
+const getApprovedClientIds = (cfg: OAuthConfig, req: Request): string[] => {
+  const cookies = parseCookies(req);
+  const raw = cookies[APPROVAL_COOKIE];
+  if (!raw) return [];
+  try {
+    const verified = verifyState<ApprovalCookiePayload>(cfg.oidcCookieSecret, raw);
+    return Array.isArray(verified.payload.approvedClientIds) ? verified.payload.approvedClientIds : [];
+  } catch {
+    return [];
+  }
+};
+
+const setApprovalCookie = (cfg: OAuthConfig, res: Response, approvedClientIds: string[]) => {
+  const value = signState(cfg.oidcCookieSecret, { approvedClientIds }, APPROVAL_TTL_SECONDS);
+  res.setHeader(
+    'Set-Cookie',
+    serializeCookie(APPROVAL_COOKIE, value, {
+      httpOnly: true,
+      secure: isHttps(cfg),
+      sameSite: 'Lax',
+      path: '/',
+      maxAgeSeconds: APPROVAL_TTL_SECONDS,
+    })
+  );
+};
+
+const getSessionId = async (cfg: OAuthConfig, storage: OAuthStorage, req: Request) => {
+  const cookies = parseCookies(req);
+  const raw = cookies[SESSION_COOKIE];
+  if (!raw) return null;
+  try {
+    const verified = verifyState<SessionCookiePayload>(cfg.oidcCookieSecret, raw);
+    const sessionId = verified.payload.sessionId;
+    if (!sessionId) return null;
+    const session = await storage.getUserSession(sessionId);
+    if (!session) return null;
+    return sessionId;
+  } catch {
+    return null;
+  }
+};
+
+const renderConsent = (cfg: OAuthConfig, res: Response, oauthReq: ClientOAuthRequest, clientName?: string) => {
+  const consentState = signState<ConsentStatePayload>(
+    cfg.oidcCookieSecret,
+    { oauth: oauthReq },
+    OIDC_STATE_TTL_SECONDS
+  );
+  const name = clientName || oauthReq.client_id;
+  const scope = oauthReq.scope || 'mcp:read';
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Authorize MCP Client</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; background: #0b0f1a; color: #e6eaf2; margin: 0; padding: 24px; }
+      .card { max-width: 520px; margin: 40px auto; background: #121a2a; border: 1px solid #223055; border-radius: 14px; padding: 20px; }
+      h1 { font-size: 18px; margin: 0 0 8px; }
+      p { margin: 6px 0; color: #b7c0d6; line-height: 1.4; }
+      .client { font-weight: 600; color: #ffffff; }
+      .scope { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; background: #0b1222; border: 1px solid #223055; padding: 6px 10px; border-radius: 10px; display: inline-block; margin-top: 6px; }
+      .row { display: flex; gap: 10px; margin-top: 16px; }
+      button { flex: 1; border-radius: 10px; padding: 10px 12px; font-weight: 600; border: 1px solid transparent; cursor: pointer; }
+      .allow { background: #4f7cff; color: #081022; }
+      .deny { background: transparent; color: #e6eaf2; border-color: #2b3b66; }
+      .fineprint { font-size: 12px; color: #8e9ab6; margin-top: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Allow access?</h1>
+      <p><span class="client">${escapeHtml(name)}</span> wants to access this MCP server.</p>
+      <div class="scope">${escapeHtml(scope)}</div>
+      <form method="post" action="/oauth/consent">
+        <input type="hidden" name="consent_state" value="${escapeAttr(consentState)}" />
+        <div class="row">
+          <button class="deny" type="submit" name="decision" value="deny">Deny</button>
+          <button class="allow" type="submit" name="decision" value="approve">Allow</button>
+        </div>
+      </form>
+      <div class="fineprint">You should only allow clients you trust. Your approval is remembered in this browser.</div>
+    </div>
+  </body>
+</html>`;
+  res.status(200).setHeader('Content-Type', 'text/html; charset=utf-8').send(html);
+};
+
+const escapeHtml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const escapeAttr = (s: string) => escapeHtml(s).replace(/'/g, '&#39;');
+
+const redirectWithError = (res: Response, oauthReq: ClientOAuthRequest, error: string, desc?: string) => {
+  const u = new URL(oauthReq.redirect_uri);
+  u.searchParams.set('error', error);
+  if (desc) u.searchParams.set('error_description', desc);
+  if (oauthReq.state) u.searchParams.set('state', oauthReq.state);
+  res.redirect(u.toString());
+};
+
+const issueAuthCodeAndRedirect = async (
+  cfg: OAuthConfig,
+  storage: OAuthStorage,
+  res: Response,
+  oauthReq: ClientOAuthRequest,
+  userClaims: Record<string, unknown>
+) => {
+  const code = randomToken(32);
+  await storage.putAuthCode({
+    code,
+    clientId: oauthReq.client_id,
+    redirectUri: oauthReq.redirect_uri,
+    codeChallenge: oauthReq.code_challenge,
+    codeChallengeMethod: 'S256',
+    scope: oauthReq.scope || 'mcp:read',
+    resource: oauthReq.resource,
+    userClaims,
+    expiresAtMs: Date.now() + AUTH_CODE_TTL_MS,
+  });
+
+  const u = new URL(oauthReq.redirect_uri);
+  u.searchParams.set('code', code);
+  if (oauthReq.state) u.searchParams.set('state', oauthReq.state);
+  res.redirect(u.toString());
+};
+
+const normalizeOauthReq = (req: Request): ClientOAuthRequest | null => {
+  const q = req.query as Record<string, unknown>;
+  const get = (k: string) => (typeof q[k] === 'string' ? (q[k] as string) : undefined);
+  const response_type = get('response_type') || '';
+  const client_id = get('client_id') || '';
+  const redirect_uri = get('redirect_uri') || '';
+  const scope = get('scope');
+  const state = get('state');
+  const code_challenge = get('code_challenge') || '';
+  const code_challenge_method = get('code_challenge_method');
+  const resource = get('resource');
+
+  if (!client_id || !redirect_uri || !code_challenge) return null;
+  return {
+    response_type,
+    client_id,
+    redirect_uri,
+    scope,
+    state,
+    code_challenge,
+    code_challenge_method,
+    resource,
+  };
+};
+
+const validateClientRequest = async (storage: OAuthStorage, oauthReq: ClientOAuthRequest) => {
+  if (oauthReq.response_type && oauthReq.response_type !== 'code') {
+    return { ok: false as const, error: 'unsupported_response_type', desc: 'Only response_type=code is supported' };
+  }
+  if (oauthReq.code_challenge_method && oauthReq.code_challenge_method !== 'S256') {
+    return { ok: false as const, error: 'invalid_request', desc: 'Only code_challenge_method=S256 is supported' };
+  }
+
+  const client = await storage.getClient(oauthReq.client_id);
+  if (!client) return { ok: false as const, error: 'unauthorized_client', desc: 'Unknown client_id' };
+  if (!client.redirectUris.includes(oauthReq.redirect_uri)) {
+    return { ok: false as const, error: 'invalid_request', desc: 'redirect_uri does not match registered value' };
+  }
+  return { ok: true as const, client };
+};
+
+export const registerAuthorizeRoutes = (router: Router, cfg: OAuthConfig, storage: OAuthStorage) => {
+  router.get('/oauth/authorize', async (req: Request, res: Response) => {
+    setNoCORS(res);
+    const oauthReq = normalizeOauthReq(req);
+    if (!oauthReq) {
+      res.status(400).send('Invalid authorization request');
+      return;
+    }
+
+    const validation = await validateClientRequest(storage, oauthReq);
+    if (!validation.ok) {
+      redirectWithError(res, oauthReq, validation.error, validation.desc);
+      return;
+    }
+
+    const sessionId = await getSessionId(cfg, storage, req);
+    if (!sessionId) {
+      const txId = randomUUID();
+      // Upstream OIDC auth uses PKCE + nonce.
+      const oidc = await getOidc();
+      const codeVerifier = oidc.randomPKCECodeVerifier();
+      const codeChallenge = await oidc.calculatePKCECodeChallenge(codeVerifier);
+      const nonce = oidc.randomNonce();
+
+      await storage.putOidcTx({
+        txId,
+        codeVerifier,
+        nonce,
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 10 * 60 * 1000,
+      });
+      const signedState = signState<OidcStatePayload>(
+        cfg.oidcCookieSecret,
+        { txId, oauth: oauthReq },
+        OIDC_STATE_TTL_SECONDS
+      );
+      const { config, redirectUri } = await getOidcClient(cfg);
+      const redirectTo = oidc.buildAuthorizationUrl(config, {
+        response_type: 'code',
+        redirect_uri: redirectUri,
+        scope: 'openid profile email offline_access',
+        state: signedState,
+        nonce,
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      });
+      res.redirect(redirectTo.toString());
+      return;
+    }
+
+    const session = await storage.getUserSession(sessionId);
+    if (!session) {
+      res.status(401).send('Not authenticated');
+      return;
+    }
+
+    const approved = new Set(getApprovedClientIds(cfg, req));
+    if (!approved.has(oauthReq.client_id)) {
+      renderConsent(cfg, res, oauthReq, validation.client.clientName);
+      return;
+    }
+
+    await issueAuthCodeAndRedirect(cfg, storage, res, oauthReq, session.userClaims);
+  });
+
+  router.post('/oauth/consent', async (req: Request, res: Response) => {
+    setNoCORS(res);
+    const decision = typeof req.body?.decision === 'string' ? (req.body.decision as string) : '';
+    const consentStateRaw = typeof req.body?.consent_state === 'string' ? (req.body.consent_state as string) : '';
+    if (!consentStateRaw) {
+      res.status(400).send('Missing consent_state');
+      return;
+    }
+
+    let oauthReq: ClientOAuthRequest;
+    try {
+      const verified = verifyState<ConsentStatePayload>(cfg.oidcCookieSecret, consentStateRaw);
+      oauthReq = verified.payload.oauth;
+    } catch {
+      res.status(400).send('Invalid consent_state');
+      return;
+    }
+
+    const validation = await validateClientRequest(storage, oauthReq);
+    if (!validation.ok) {
+      redirectWithError(res, oauthReq, validation.error, validation.desc);
+      return;
+    }
+
+    const sessionId = await getSessionId(cfg, storage, req);
+    if (!sessionId) {
+      redirectWithError(res, oauthReq, 'login_required', 'No active session');
+      return;
+    }
+    const session = await storage.getUserSession(sessionId);
+    if (!session) {
+      redirectWithError(res, oauthReq, 'login_required', 'No active session');
+      return;
+    }
+
+    if (decision !== 'approve') {
+      redirectWithError(res, oauthReq, 'access_denied', 'User denied access');
+      return;
+    }
+
+    const approved = new Set(getApprovedClientIds(cfg, req));
+    approved.add(oauthReq.client_id);
+    setApprovalCookie(cfg, res, [...approved]);
+
+    await issueAuthCodeAndRedirect(cfg, storage, res, oauthReq, session.userClaims);
+  });
+
+  router.get('/oauth/callback', async (req: Request, res: Response) => {
+    setNoCORS(res);
+    const params = req.query as Record<string, unknown>;
+    const code = typeof params.code === 'string' ? (params.code as string) : '';
+    const state = typeof params.state === 'string' ? (params.state as string) : '';
+    if (!code || !state) {
+      res.status(400).send('Missing code or state');
+      return;
+    }
+
+    let verified: { payload: OidcStatePayload };
+    try {
+      verified = verifyState<OidcStatePayload>(cfg.oidcCookieSecret, state);
+    } catch {
+      res.status(400).send('Invalid state');
+      return;
+    }
+
+    const tx = await storage.consumeOidcTx(verified.payload.txId);
+    if (!tx) {
+      res.status(400).send('Invalid or expired transaction');
+      return;
+    }
+
+    const oauthReq = verified.payload.oauth;
+    const validation = await validateClientRequest(storage, oauthReq);
+    if (!validation.ok) {
+      redirectWithError(res, oauthReq, validation.error, validation.desc);
+      return;
+    }
+
+    const { config } = await getOidcClient(cfg);
+    const oidc = await getOidc();
+    let tokens: Awaited<ReturnType<typeof oidc.authorizationCodeGrant>>;
+    try {
+      const currentUrl = new URL(`${cfg.oauthServerUrl}${req.originalUrl}`);
+      tokens = await oidc.authorizationCodeGrant(
+        config,
+        currentUrl,
+        {
+          pkceCodeVerifier: tx.codeVerifier,
+          expectedState: state,
+          expectedNonce: tx.nonce,
+        },
+        {
+          // ensure refresh token from upstream if supported
+          scope: 'openid profile email offline_access',
+        }
+      );
+    } catch {
+      res.status(400).send('OIDC callback failed');
+      return;
+    }
+
+    const idClaims = (tokens.claims?.() ?? {}) as Record<string, unknown>;
+    let userinfo: Record<string, unknown> = {};
+    try {
+      if (typeof tokens.access_token === 'string') {
+        const sub = typeof idClaims.sub === 'string' ? idClaims.sub : '';
+        if (sub) {
+          userinfo = (await oidc.fetchUserInfo(config, tokens.access_token, sub)) as Record<string, unknown>;
+        }
+      }
+    } catch {
+      userinfo = {};
+    }
+
+    const userClaims = { ...userinfo, ...idClaims };
+    for (const claim of cfg.oidcRequiredClaims) {
+      if (userClaims[claim] == null) {
+        res.status(403).send(`Missing required claim: ${claim}`);
+        return;
+      }
+    }
+
+    const sessionId = randomUUID();
+    const upstreamRefreshToken = typeof tokens.refresh_token === 'string' ? tokens.refresh_token : undefined;
+    const upstreamRefreshTokenEnc = upstreamRefreshToken
+      ? encryptAes256Gcm(derive32ByteKey(cfg.oidcCookieSecret), upstreamRefreshToken)
+      : undefined;
+
+    await storage.putUserSession({
+      sessionId,
+      userClaims,
+      upstreamRefreshTokenEnc,
+      createdAtMs: Date.now(),
+      expiresAtMs: Date.now() + SESSION_TTL_SECONDS * 1000,
+    });
+
+    const sessionCookieVal = signState<SessionCookiePayload>(cfg.oidcCookieSecret, { sessionId }, SESSION_TTL_SECONDS);
+    res.setHeader(
+      'Set-Cookie',
+      serializeCookie(SESSION_COOKIE, sessionCookieVal, {
+        httpOnly: true,
+        secure: isHttps(cfg),
+        sameSite: 'Lax',
+        path: '/',
+        maxAgeSeconds: SESSION_TTL_SECONDS,
+      })
+    );
+
+    const approved = new Set(getApprovedClientIds(cfg, req));
+    if (!approved.has(oauthReq.client_id)) {
+      renderConsent(cfg, res, oauthReq, validation.client.clientName);
+      return;
+    }
+
+    await issueAuthCodeAndRedirect(cfg, storage, res, oauthReq, userClaims);
+  });
+};

--- a/src/auth/routes/debug.ts
+++ b/src/auth/routes/debug.ts
@@ -1,0 +1,35 @@
+/**
+ * Optional OAuth debug endpoint.
+ *
+ * When enabled, exposes a small, authenticated view of the current access token claims to help
+ * validate the auth flow without logging sensitive bearer tokens.
+ */
+import type { Request, Response, Router } from 'express';
+
+import type { OAuthConfig } from '../../config';
+import { bearerAuth } from '../middleware';
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+export const registerDebugRoutes = (router: Router, cfg: OAuthConfig) => {
+  router.get('/oauth/debug', bearerAuth(cfg), (req: Request, res: Response) => {
+    const claims = req.mcpAuth!.claims;
+    const exp = typeof claims.exp === 'number' ? claims.exp : undefined;
+    const iat = typeof claims.iat === 'number' ? claims.iat : undefined;
+    const remaining = exp ? Math.max(0, exp - nowSec()) : null;
+
+    res.json({
+      subject: claims.sub,
+      scope: claims.scope,
+      audience: claims.aud,
+      issuer: claims.iss,
+      iat,
+      exp,
+      expires_in_seconds: remaining,
+      required_claims_present: cfg.oidcRequiredClaims.reduce<Record<string, boolean>>((acc, k) => {
+        acc[k] = (claims as unknown as Record<string, unknown>)[k] != null;
+        return acc;
+      }, {}),
+    });
+  });
+};

--- a/src/auth/routes/register.ts
+++ b/src/auth/routes/register.ts
@@ -1,0 +1,124 @@
+/**
+ * Dynamic Client Registration (DCR) endpoint.
+ *
+ * Allows MCP clients (like Cursor) to register `client_id` + redirect URIs at runtime so they can
+ * initiate the OAuth authorization code flow against `/oauth/authorize`.
+ */
+import { randomUUID } from 'crypto';
+import type { Request, Response, Router } from 'express';
+
+import type { OAuthConfig } from '../../config';
+import type { OAuthStorage, OAuthClientMetadata } from '../storage';
+
+type DcrRequest = {
+  client_name?: string;
+  client_uri?: string;
+  redirect_uris: string[];
+  grant_types?: string[];
+  response_types?: string[];
+  token_endpoint_auth_method?: string;
+  scope?: string;
+};
+
+const isLocalhostRedirect = (uri: string) => {
+  try {
+    const u = new URL(uri);
+    if (u.protocol === 'https:') return true;
+    if (u.protocol !== 'http:') return false;
+    return u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]';
+  } catch {
+    return false;
+  }
+};
+
+const isCursorRedirect = (uri: string) => {
+  try {
+    const u = new URL(uri);
+    // Cursor uses a custom URI scheme for OAuth callbacks.
+    return u.protocol === 'cursor:';
+  } catch {
+    return false;
+  }
+};
+
+const setNoCORS = (res: Response) => {
+  // Intentional: don't reflect Origin on OAuth endpoints.
+  res.removeHeader('Access-Control-Allow-Origin');
+};
+
+export const registerDcrRoutes = (router: Router, _cfg: OAuthConfig, storage: OAuthStorage) => {
+  router.post('/oauth/register', async (req: Request, res: Response) => {
+    setNoCORS(res);
+    const body = req.body as Partial<DcrRequest> | undefined;
+
+    if (!body || !Array.isArray(body.redirect_uris) || body.redirect_uris.length === 0) {
+      res.status(400).json({ error: 'invalid_client_metadata', error_description: 'redirect_uris is required' });
+      return;
+    }
+
+    const redirectUris = body.redirect_uris.filter((u) => typeof u === 'string');
+    if (redirectUris.length !== body.redirect_uris.length) {
+      res.status(400).json({ error: 'invalid_client_metadata', error_description: 'redirect_uris must be strings' });
+      return;
+    }
+
+    for (const uri of redirectUris) {
+      if (!isLocalhostRedirect(uri) && !isCursorRedirect(uri)) {
+        res.status(400).json({
+          error: 'invalid_redirect_uri',
+          error_description: `redirect_uri must be https, http://localhost, or cursor://: ${uri}`,
+        });
+        return;
+      }
+    }
+
+    const tokenEndpointAuthMethod = (body.token_endpoint_auth_method ?? 'none') as string;
+    if (tokenEndpointAuthMethod !== 'none') {
+      res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'Only token_endpoint_auth_method="none" is supported',
+      });
+      return;
+    }
+
+    const grantTypes = body.grant_types ?? ['authorization_code', 'refresh_token'];
+    const responseTypes = body.response_types ?? ['code'];
+
+    if (!grantTypes.includes('authorization_code') || !responseTypes.includes('code')) {
+      res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'grant_types must include authorization_code and response_types must include code',
+      });
+      return;
+    }
+
+    const clientId = randomUUID();
+    const createdAtMs = Date.now();
+
+    const metadata: OAuthClientMetadata = {
+      clientId,
+      clientName: body.client_name,
+      clientUri: body.client_uri,
+      redirectUris,
+      grantTypes,
+      responseTypes,
+      tokenEndpointAuthMethod: 'none',
+      scope: body.scope,
+      createdAtMs,
+    };
+
+    await storage.createClient(metadata);
+
+    res.status(201).json({
+      client_id: clientId,
+      client_id_issued_at: Math.floor(createdAtMs / 1000),
+      token_endpoint_auth_method: 'none',
+      redirect_uris: redirectUris,
+      grant_types: grantTypes,
+      response_types: responseTypes,
+      client_name: body.client_name,
+      client_uri: body.client_uri,
+      scope: body.scope,
+    });
+  });
+};

--- a/src/auth/routes/token.ts
+++ b/src/auth/routes/token.ts
@@ -1,0 +1,202 @@
+/**
+ * OAuth Token Endpoint.
+ *
+ * Exchanges authorization codes for access/refresh tokens and supports refresh token rotation.
+ * Enforces PKCE and issues signed JWT access tokens used by `bearerAuth` to protect `/mcp`.
+ */
+import type { Request, Response, Router } from 'express';
+
+import type { OAuthConfig } from '../../config';
+import { randomToken } from '../crypto';
+import { verifyPkceS256 } from '../pkce';
+import type { OAuthStorage } from '../storage';
+import { signAccessToken } from '../tokens';
+import { hashRefreshToken } from '../token_utils';
+
+const ACCESS_TOKEN_TTL_SECONDS = 8 * 60 * 60;
+const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+const LOCK_TTL_SECONDS = 5;
+
+const setNoCORS = (res: Response) => {
+  res.removeHeader('Access-Control-Allow-Origin');
+};
+
+const setNoStore = (res: Response) => {
+  // RFC 6749 requires these headers on responses containing tokens/credentials.
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+};
+
+const jsonError = (res: Response, status: number, error: string, desc?: string) => {
+  res.status(status).json({ error, ...(desc ? { error_description: desc } : {}) });
+};
+
+export const registerTokenRoutes = (router: Router, cfg: OAuthConfig, storage: OAuthStorage) => {
+  router.post('/oauth/token', async (req: Request, res: Response) => {
+    setNoCORS(res);
+    setNoStore(res);
+    const body = req.body as Record<string, unknown>;
+    const grantType = typeof body.grant_type === 'string' ? (body.grant_type as string) : '';
+    const clientId = typeof body.client_id === 'string' ? (body.client_id as string) : '';
+
+    if (!grantType) {
+      jsonError(res, 400, 'invalid_request', 'grant_type is required');
+      return;
+    }
+    if (!clientId) {
+      jsonError(res, 400, 'invalid_request', 'client_id is required');
+      return;
+    }
+
+    const client = await storage.getClient(clientId);
+    if (!client) {
+      jsonError(res, 400, 'invalid_client', 'Unknown client_id');
+      return;
+    }
+
+    if (client.tokenEndpointAuthMethod !== 'none') {
+      jsonError(res, 400, 'invalid_client', 'Unsupported token_endpoint_auth_method');
+      return;
+    }
+
+    if (grantType === 'authorization_code') {
+      const code = typeof body.code === 'string' ? (body.code as string) : '';
+      const redirectUri = typeof body.redirect_uri === 'string' ? (body.redirect_uri as string) : '';
+      const codeVerifier = typeof body.code_verifier === 'string' ? (body.code_verifier as string) : '';
+
+      if (!code || !redirectUri || !codeVerifier) {
+        jsonError(res, 400, 'invalid_request', 'code, redirect_uri, and code_verifier are required');
+        return;
+      }
+
+      if (!client.redirectUris.includes(redirectUri)) {
+        jsonError(res, 400, 'invalid_grant', 'redirect_uri mismatch');
+        return;
+      }
+
+      const record = await storage.consumeAuthCode(code);
+      if (!record) {
+        jsonError(res, 400, 'invalid_grant', 'Invalid or expired code');
+        return;
+      }
+      if (record.clientId !== clientId || record.redirectUri !== redirectUri) {
+        jsonError(res, 400, 'invalid_grant', 'Invalid code for this client');
+        return;
+      }
+      if (record.codeChallengeMethod !== 'S256' || !verifyPkceS256(codeVerifier, record.codeChallenge)) {
+        jsonError(res, 400, 'invalid_grant', 'PKCE verification failed');
+        return;
+      }
+
+      const subject = String(record.userClaims.sub ?? '');
+      if (!subject) {
+        jsonError(res, 400, 'invalid_grant', 'Missing subject');
+        return;
+      }
+
+      const accessToken = await signAccessToken({
+        signingSecret: cfg.jwtSigningSecret,
+        issuer: cfg.oauthServerUrl,
+        audience: cfg.oauthServerUrl,
+        subject,
+        scope: record.scope,
+        ttlSeconds: ACCESS_TOKEN_TTL_SECONDS,
+        extraClaims: record.userClaims,
+      });
+
+      const refreshToken = randomToken(32);
+      const refreshTokenHash = hashRefreshToken(cfg.jwtSigningSecret, refreshToken);
+      const nowMs = Date.now();
+
+      await storage.putRefreshToken({
+        refreshTokenHash,
+        clientId,
+        scope: record.scope,
+        resource: record.resource,
+        userClaims: record.userClaims,
+        createdAtMs: nowMs,
+        expiresAtMs: nowMs + REFRESH_TOKEN_TTL_SECONDS * 1000,
+      });
+
+      res.json({
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_TTL_SECONDS,
+        refresh_token: refreshToken,
+        scope: record.scope,
+      });
+      return;
+    }
+
+    if (grantType === 'refresh_token') {
+      const refreshToken = typeof body.refresh_token === 'string' ? (body.refresh_token as string) : '';
+      if (!refreshToken) {
+        jsonError(res, 400, 'invalid_request', 'refresh_token is required');
+        return;
+      }
+
+      const oldHash = hashRefreshToken(cfg.jwtSigningSecret, refreshToken);
+      const lockKey = `oauth:rtlock:${oldHash}`;
+      const lockToken = await storage.acquireLock(lockKey, LOCK_TTL_SECONDS);
+      if (!lockToken) {
+        jsonError(res, 429, 'slow_down', 'Retry refresh');
+        return;
+      }
+
+      try {
+        const record = await storage.getRefreshTokenByHash(oldHash);
+        if (!record) {
+          jsonError(res, 400, 'invalid_grant', 'Invalid refresh_token');
+          return;
+        }
+        if (record.clientId !== clientId) {
+          jsonError(res, 400, 'invalid_grant', 'refresh_token client mismatch');
+          return;
+        }
+
+        const subject = String(record.userClaims.sub ?? '');
+        if (!subject) {
+          jsonError(res, 400, 'invalid_grant', 'Missing subject');
+          return;
+        }
+
+        const accessToken = await signAccessToken({
+          signingSecret: cfg.jwtSigningSecret,
+          issuer: cfg.oauthServerUrl,
+          audience: cfg.oauthServerUrl,
+          subject,
+          scope: record.scope,
+          ttlSeconds: ACCESS_TOKEN_TTL_SECONDS,
+          extraClaims: record.userClaims,
+        });
+
+        const newRefreshToken = randomToken(32);
+        const newHash = hashRefreshToken(cfg.jwtSigningSecret, newRefreshToken);
+        const nowMs = Date.now();
+        await storage.putRefreshToken({
+          refreshTokenHash: newHash,
+          clientId,
+          scope: record.scope,
+          resource: record.resource,
+          userClaims: record.userClaims,
+          createdAtMs: nowMs,
+          expiresAtMs: nowMs + REFRESH_TOKEN_TTL_SECONDS * 1000,
+        });
+        await storage.deleteRefreshTokenByHash(oldHash);
+
+        res.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: ACCESS_TOKEN_TTL_SECONDS,
+          refresh_token: newRefreshToken,
+          scope: record.scope,
+        });
+      } finally {
+        await storage.releaseLock(lockKey, lockToken);
+      }
+      return;
+    }
+
+    jsonError(res, 400, 'unsupported_grant_type', 'Only authorization_code and refresh_token are supported');
+  });
+};

--- a/src/auth/routes/well_known.ts
+++ b/src/auth/routes/well_known.ts
@@ -1,0 +1,70 @@
+/**
+ * OAuth metadata endpoints ("well-known").
+ *
+ * Serves protected resource metadata and authorization server metadata so MCP clients can discover
+ * where to register, authorize, and exchange tokens.
+ */
+import type { Request, Response, Router } from 'express';
+
+import type { OAuthConfig } from '../../config';
+
+const setPublicCors = (res: Response) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+};
+
+export const registerWellKnownRoutes = (router: Router, cfg: OAuthConfig) => {
+  const baseResource = cfg.oauthServerUrl;
+  const mcpResource = `${cfg.oauthServerUrl}/mcp`;
+
+  router.options('/.well-known/oauth-protected-resource', (_req, res) => {
+    setPublicCors(res);
+    res.status(204).end();
+  });
+
+  router.get('/.well-known/oauth-protected-resource', (_req: Request, res: Response) => {
+    setPublicCors(res);
+    res.json({
+      resource: baseResource,
+      authorization_servers: [cfg.oauthServerUrl],
+      scopes_supported: ['mcp:read'],
+      bearer_methods_supported: ['header'],
+    });
+  });
+
+  router.options('/.well-known/oauth-protected-resource/mcp', (_req, res) => {
+    setPublicCors(res);
+    res.status(204).end();
+  });
+
+  router.get('/.well-known/oauth-protected-resource/mcp', (_req: Request, res: Response) => {
+    setPublicCors(res);
+    res.json({
+      resource: mcpResource,
+      authorization_servers: [cfg.oauthServerUrl],
+      scopes_supported: ['mcp:read'],
+      bearer_methods_supported: ['header'],
+    });
+  });
+
+  router.options('/.well-known/oauth-authorization-server', (_req, res) => {
+    setPublicCors(res);
+    res.status(204).end();
+  });
+
+  router.get('/.well-known/oauth-authorization-server', (_req: Request, res: Response) => {
+    setPublicCors(res);
+    res.json({
+      issuer: cfg.oauthServerUrl,
+      authorization_endpoint: `${cfg.oauthServerUrl}/oauth/authorize`,
+      token_endpoint: `${cfg.oauthServerUrl}/oauth/token`,
+      registration_endpoint: `${cfg.oauthServerUrl}/oauth/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: ['mcp:read'],
+      code_challenge_methods_supported: ['S256'],
+    });
+  });
+};

--- a/src/auth/state.ts
+++ b/src/auth/state.ts
@@ -1,0 +1,32 @@
+/**
+ * Signed, expiring state blobs for OAuth/OIDC redirects and consent.
+ *
+ * Used to carry transient data across browser redirects (e.g. OIDC transaction IDs, original OAuth
+ * request parameters) with integrity and expiration.
+ */
+import { base64url, hmacSha256Hex, timingSafeEqualStr } from './crypto';
+
+export type SignedState<T> = {
+  payload: T;
+  iat: number;
+  exp: number;
+};
+
+export const signState = <T>(secret: string, payload: T, ttlSeconds: number) => {
+  const now = Math.floor(Date.now() / 1000);
+  const body: SignedState<T> = { payload, iat: now, exp: now + ttlSeconds };
+  const bodyB64 = base64url.encode(JSON.stringify(body));
+  const sig = hmacSha256Hex(secret, bodyB64);
+  return `${sig}.${bodyB64}`;
+};
+
+export const verifyState = <T>(secret: string, state: string): SignedState<T> => {
+  const [sig, bodyB64] = state.split('.', 2);
+  if (!sig || !bodyB64) throw new Error('Invalid state format');
+  const expected = hmacSha256Hex(secret, bodyB64);
+  if (!timingSafeEqualStr(sig, expected)) throw new Error('Invalid state signature');
+  const decoded = JSON.parse(base64url.decode(bodyB64).toString('utf8')) as SignedState<T>;
+  const now = Math.floor(Date.now() / 1000);
+  if (decoded.exp < now) throw new Error('State expired');
+  return decoded;
+};

--- a/src/auth/storage/index.ts
+++ b/src/auth/storage/index.ts
@@ -1,0 +1,21 @@
+/**
+ * OAuth storage selection.
+ *
+ * Chooses the persistence backend used by the OAuth/OIDC flow (clients, auth codes, refresh tokens,
+ * user sessions, and OIDC transaction state).
+ */
+import type { OAuthConfig } from '../../config';
+
+import { MemoryOAuthStorage } from './memory';
+import { RedisOAuthStorage } from './redis';
+import type { OAuthStorage } from './interface';
+
+export const createOAuthStorage = (cfg: OAuthConfig): OAuthStorage => {
+  if (cfg.oauthStorage === 'redis') {
+    if (!cfg.redisUrl) throw new Error('redisUrl is required when oauthStorage=redis');
+    return new RedisOAuthStorage(cfg.redisUrl);
+  }
+  return new MemoryOAuthStorage();
+};
+
+export type * from './interface';

--- a/src/auth/storage/interface.ts
+++ b/src/auth/storage/interface.ts
@@ -1,0 +1,77 @@
+/**
+ * Storage contract for the OAuth/OIDC flow.
+ *
+ * The OAuth endpoints persist and consume records (client registrations, auth codes, refresh tokens,
+ * user sessions, and OIDC transactions) through this interface so we can swap in-memory vs Redis.
+ */
+export type OAuthClientMetadata = {
+  clientId: string;
+  clientName?: string;
+  clientUri?: string;
+  redirectUris: string[];
+  grantTypes: string[];
+  responseTypes: string[];
+  tokenEndpointAuthMethod: 'none';
+  scope?: string;
+  createdAtMs: number;
+};
+
+export type AuthCodeRecord = {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+  scope: string;
+  resource?: string;
+  userClaims: Record<string, unknown>;
+  expiresAtMs: number;
+};
+
+export type RefreshTokenRecord = {
+  refreshTokenHash: string;
+  clientId: string;
+  scope: string;
+  resource?: string;
+  userClaims: Record<string, unknown>;
+  expiresAtMs: number;
+  createdAtMs: number;
+};
+
+export type UserSessionRecord = {
+  sessionId: string;
+  userClaims: Record<string, unknown>;
+  upstreamRefreshTokenEnc?: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
+
+export type OidcTxRecord = {
+  txId: string;
+  codeVerifier: string;
+  nonce?: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
+
+export interface OAuthStorage {
+  getClient(clientId: string): Promise<OAuthClientMetadata | null>;
+  createClient(client: OAuthClientMetadata): Promise<void>;
+
+  putAuthCode(record: AuthCodeRecord): Promise<void>;
+  consumeAuthCode(code: string): Promise<AuthCodeRecord | null>;
+
+  putRefreshToken(record: RefreshTokenRecord): Promise<void>;
+  getRefreshTokenByHash(refreshTokenHash: string): Promise<RefreshTokenRecord | null>;
+  deleteRefreshTokenByHash(refreshTokenHash: string): Promise<void>;
+
+  putUserSession(record: UserSessionRecord): Promise<void>;
+  getUserSession(sessionId: string): Promise<UserSessionRecord | null>;
+  deleteUserSession(sessionId: string): Promise<void>;
+
+  putOidcTx(record: OidcTxRecord): Promise<void>;
+  consumeOidcTx(txId: string): Promise<OidcTxRecord | null>;
+
+  acquireLock(key: string, ttlSeconds: number): Promise<string | null>;
+  releaseLock(key: string, token: string): Promise<void>;
+}

--- a/src/auth/storage/memory.ts
+++ b/src/auth/storage/memory.ts
@@ -1,0 +1,109 @@
+/**
+ * In-memory backend for `OAuthStorage`.
+ *
+ * Supports the full OAuth/OIDC flow in a single process (DCR, auth codes, refresh tokens, sessions,
+ * and OIDC transactions). Intended for local dev/tests only; state is not durable.
+ */
+import { randomUUID } from 'crypto';
+
+import type {
+  AuthCodeRecord,
+  OAuthClientMetadata,
+  OAuthStorage,
+  OidcTxRecord,
+  RefreshTokenRecord,
+  UserSessionRecord,
+} from './interface';
+
+/**
+ * In-memory persistence for the OAuth/OIDC flow.
+ *
+ * Used by the OAuth routes to store client registrations, short-lived auth codes,
+ * refresh tokens, user sessions, and transient OIDC transaction state during login.
+ * This is best suited for local dev/tests (state is lost on restart; not shared across replicas).
+ */
+export class MemoryOAuthStorage implements OAuthStorage {
+  private clients = new Map<string, OAuthClientMetadata>();
+  private authCodes = new Map<string, AuthCodeRecord>();
+  private refreshTokens = new Map<string, RefreshTokenRecord>();
+  private sessions = new Map<string, UserSessionRecord>();
+  private oidcTxs = new Map<string, OidcTxRecord>();
+  private locks = new Map<string, { token: string; expiresAtMs: number }>();
+
+  async getClient(clientId: string): Promise<OAuthClientMetadata | null> {
+    return this.clients.get(clientId) ?? null;
+  }
+
+  async createClient(client: OAuthClientMetadata): Promise<void> {
+    this.clients.set(client.clientId, client);
+  }
+
+  async putAuthCode(record: AuthCodeRecord): Promise<void> {
+    this.authCodes.set(record.code, record);
+  }
+
+  async consumeAuthCode(code: string): Promise<AuthCodeRecord | null> {
+    const record = this.authCodes.get(code) ?? null;
+    if (record) this.authCodes.delete(code);
+    if (!record) return null;
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async putRefreshToken(record: RefreshTokenRecord): Promise<void> {
+    this.refreshTokens.set(record.refreshTokenHash, record);
+  }
+
+  async getRefreshTokenByHash(refreshTokenHash: string): Promise<RefreshTokenRecord | null> {
+    const record = this.refreshTokens.get(refreshTokenHash) ?? null;
+    if (!record) return null;
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async deleteRefreshTokenByHash(refreshTokenHash: string): Promise<void> {
+    this.refreshTokens.delete(refreshTokenHash);
+  }
+
+  async putUserSession(record: UserSessionRecord): Promise<void> {
+    this.sessions.set(record.sessionId, record);
+  }
+
+  async getUserSession(sessionId: string): Promise<UserSessionRecord | null> {
+    const record = this.sessions.get(sessionId) ?? null;
+    if (!record) return null;
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async deleteUserSession(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
+  }
+
+  async putOidcTx(record: OidcTxRecord): Promise<void> {
+    this.oidcTxs.set(record.txId, record);
+  }
+
+  async consumeOidcTx(txId: string): Promise<OidcTxRecord | null> {
+    const record = this.oidcTxs.get(txId) ?? null;
+    if (record) this.oidcTxs.delete(txId);
+    if (!record) return null;
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async acquireLock(key: string, ttlSeconds: number): Promise<string | null> {
+    const existing = this.locks.get(key);
+    if (existing && Date.now() < existing.expiresAtMs) return null;
+    const token = randomUUID();
+    this.locks.set(key, { token, expiresAtMs: Date.now() + ttlSeconds * 1000 });
+    return token;
+  }
+
+  async releaseLock(key: string, token: string): Promise<void> {
+    const existing = this.locks.get(key);
+    if (!existing) return;
+    if (existing.token !== token) return;
+    this.locks.delete(key);
+  }
+}

--- a/src/auth/storage/redis.ts
+++ b/src/auth/storage/redis.ts
@@ -1,0 +1,144 @@
+/**
+ * Redis backend for `OAuthStorage`.
+ *
+ * Persists OAuth/OIDC state (DCR clients, auth codes, refresh tokens, sessions, OIDC transactions)
+ * with TTLs so the auth flow survives restarts and can be shared across instances.
+ */
+import { randomUUID } from 'crypto';
+import Redis from 'ioredis';
+
+import type {
+  AuthCodeRecord,
+  OAuthClientMetadata,
+  OAuthStorage,
+  OidcTxRecord,
+  RefreshTokenRecord,
+  UserSessionRecord,
+} from './interface';
+
+const json = {
+  stringify: (value: unknown) => JSON.stringify(value),
+  parse: <T>(value: string) => JSON.parse(value) as T,
+};
+
+/**
+ * Redis-backed persistence for the OAuth/OIDC flow.
+ *
+ * Used by the OAuth routes to store client registrations, auth codes, refresh tokens,
+ * user sessions, and transient OIDC transaction state with TTLs so the auth server can
+ * be restarted or horizontally scaled without losing state mid-flow.
+ */
+export class RedisOAuthStorage implements OAuthStorage {
+  private redis: Redis;
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl, { lazyConnect: false });
+  }
+
+  private keyClient(clientId: string) {
+    return `oauth:client:${clientId}`;
+  }
+  private keyAuthCode(code: string) {
+    return `oauth:code:${code}`;
+  }
+  private keyRefreshToken(hash: string) {
+    return `oauth:rt:${hash}`;
+  }
+  private keySession(sessionId: string) {
+    return `oauth:sess:${sessionId}`;
+  }
+  private keyOidcTx(txId: string) {
+    return `oauth:oidctx:${txId}`;
+  }
+
+  async getClient(clientId: string): Promise<OAuthClientMetadata | null> {
+    const raw = await this.redis.get(this.keyClient(clientId));
+    if (!raw) return null;
+    return json.parse<OAuthClientMetadata>(raw);
+  }
+
+  async createClient(client: OAuthClientMetadata): Promise<void> {
+    await this.redis.set(this.keyClient(client.clientId), json.stringify(client));
+  }
+
+  async putAuthCode(record: AuthCodeRecord): Promise<void> {
+    const ttlSeconds = Math.max(1, Math.ceil((record.expiresAtMs - Date.now()) / 1000));
+    await this.redis.set(this.keyAuthCode(record.code), json.stringify(record), 'EX', ttlSeconds);
+  }
+
+  async consumeAuthCode(code: string): Promise<AuthCodeRecord | null> {
+    const key = this.keyAuthCode(code);
+    const raw = await this.redis.get(key);
+    if (!raw) return null;
+    await this.redis.del(key);
+    const record = json.parse<AuthCodeRecord>(raw);
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async putRefreshToken(record: RefreshTokenRecord): Promise<void> {
+    const ttlSeconds = Math.max(1, Math.ceil((record.expiresAtMs - Date.now()) / 1000));
+    await this.redis.set(this.keyRefreshToken(record.refreshTokenHash), json.stringify(record), 'EX', ttlSeconds);
+  }
+
+  async getRefreshTokenByHash(refreshTokenHash: string): Promise<RefreshTokenRecord | null> {
+    const raw = await this.redis.get(this.keyRefreshToken(refreshTokenHash));
+    if (!raw) return null;
+    const record = json.parse<RefreshTokenRecord>(raw);
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async deleteRefreshTokenByHash(refreshTokenHash: string): Promise<void> {
+    await this.redis.del(this.keyRefreshToken(refreshTokenHash));
+  }
+
+  async putUserSession(record: UserSessionRecord): Promise<void> {
+    const ttlSeconds = Math.max(1, Math.ceil((record.expiresAtMs - Date.now()) / 1000));
+    await this.redis.set(this.keySession(record.sessionId), json.stringify(record), 'EX', ttlSeconds);
+  }
+
+  async getUserSession(sessionId: string): Promise<UserSessionRecord | null> {
+    const raw = await this.redis.get(this.keySession(sessionId));
+    if (!raw) return null;
+    const record = json.parse<UserSessionRecord>(raw);
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async deleteUserSession(sessionId: string): Promise<void> {
+    await this.redis.del(this.keySession(sessionId));
+  }
+
+  async putOidcTx(record: OidcTxRecord): Promise<void> {
+    const ttlSeconds = Math.max(1, Math.ceil((record.expiresAtMs - Date.now()) / 1000));
+    await this.redis.set(this.keyOidcTx(record.txId), json.stringify(record), 'EX', ttlSeconds);
+  }
+
+  async consumeOidcTx(txId: string): Promise<OidcTxRecord | null> {
+    const key = this.keyOidcTx(txId);
+    const raw = await this.redis.get(key);
+    if (!raw) return null;
+    await this.redis.del(key);
+    const record = json.parse<OidcTxRecord>(raw);
+    if (Date.now() > record.expiresAtMs) return null;
+    return record;
+  }
+
+  async acquireLock(key: string, ttlSeconds: number): Promise<string | null> {
+    const token = randomUUID();
+    const result = await this.redis.set(key, token, 'EX', ttlSeconds, 'NX');
+    return result === 'OK' ? token : null;
+  }
+
+  async releaseLock(key: string, token: string): Promise<void> {
+    const lua = `
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("del", KEYS[1])
+      else
+        return 0
+      end
+    `;
+    await this.redis.eval(lua, 1, key, token);
+  }
+}

--- a/src/auth/token_utils.ts
+++ b/src/auth/token_utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Token-related helpers for the OAuth refresh-token flow.
+ *
+ * Refresh tokens are never stored in plaintext; we store an HMAC-derived identifier and look it up
+ * during `/oauth/token` refresh requests.
+ */
+import { hmacSha256Hex } from './crypto';
+
+export const hashRefreshToken = (secret: string, refreshToken: string) => {
+  // HMAC (not plain hash) prevents offline guessing if token format ever changes.
+  return hmacSha256Hex(secret, refreshToken);
+};

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -1,0 +1,56 @@
+/**
+ * Access token (JWT) primitives used by the OAuth token endpoint and MCP bearer auth.
+ *
+ * We issue short-lived HS256 JWTs to clients and verify them on the protected MCP endpoint.
+ */
+export type AccessTokenClaims = {
+  sub: string;
+  iss: string;
+  aud: string;
+  scope: string;
+  [key: string]: unknown;
+};
+
+const textEncoder = new TextEncoder();
+
+const getJose = async () => (await import('jose')) as typeof import('jose');
+
+const secretKey = (secret: string) => {
+  return textEncoder.encode(secret);
+};
+
+export const signAccessToken = async (opts: {
+  signingSecret: string;
+  issuer: string;
+  audience: string;
+  subject: string;
+  scope: string;
+  ttlSeconds: number;
+  extraClaims?: Record<string, unknown>;
+}) => {
+  const { SignJWT } = await getJose();
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = new SignJWT({ scope: opts.scope, ...(opts.extraClaims ?? {}) })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt(now)
+    .setIssuer(opts.issuer)
+    .setAudience(opts.audience)
+    .setSubject(opts.subject)
+    .setExpirationTime(now + opts.ttlSeconds);
+
+  return await jwt.sign(secretKey(opts.signingSecret));
+};
+
+export const verifyAccessToken = async (opts: {
+  token: string;
+  signingSecret: string;
+  issuer: string;
+  audience: string;
+}) => {
+  const { jwtVerify } = await getJose();
+  const { payload } = await jwtVerify(opts.token, secretKey(opts.signingSecret), {
+    issuer: opts.issuer,
+    audience: opts.audience,
+  });
+  return payload as unknown as AccessTokenClaims;
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,3 +9,63 @@ export const elasticsearchConfig = {
   apiKey: process.env.ELASTICSEARCH_API_KEY,
   index: process.env.ELASTICSEARCH_INDEX || 'semantic-code-search',
 };
+
+const isTruthy = (value: string | undefined) => {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'y', 'on'].includes(value.toLowerCase());
+};
+
+const requireEnv = (key: string) => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required env var: ${key}`);
+  }
+  return value;
+};
+
+export const oauthEnabled = isTruthy(process.env.OIDC_AUTH_ENABLED);
+export const oauthDebugEnabled = isTruthy(process.env.OAUTH_DEBUG_ENABLED);
+
+export type OAuthConfig = {
+  oauthServerUrl: string;
+  jwtSigningSecret: string;
+  oidcIssuer: string;
+  oidcClientId: string;
+  oidcClientSecret: string;
+  oidcCookieSecret: string;
+  oidcRequiredClaims: string[];
+  oauthStorage: 'memory' | 'redis';
+  redisUrl?: string;
+  debugEnabled: boolean;
+};
+
+export const loadOauthConfig = (): OAuthConfig | null => {
+  if (!oauthEnabled) return null;
+
+  const oauthStorage = (process.env.OAUTH_STORAGE || 'memory') as OAuthConfig['oauthStorage'];
+  if (oauthStorage !== 'memory' && oauthStorage !== 'redis') {
+    throw new Error(`Invalid OAUTH_STORAGE: ${oauthStorage}. Expected "memory" or "redis".`);
+  }
+
+  const cfg: OAuthConfig = {
+    oauthServerUrl: requireEnv('OAUTH_SERVER_URL').replace(/\/+$/, ''),
+    jwtSigningSecret: requireEnv('JWT_SIGNING_SECRET'),
+    oidcIssuer: requireEnv('OIDC_ISSUER'),
+    oidcClientId: requireEnv('OIDC_CLIENT_ID'),
+    oidcClientSecret: requireEnv('OIDC_CLIENT_SECRET'),
+    oidcCookieSecret: requireEnv('OIDC_COOKIE_SECRET'),
+    oidcRequiredClaims: (process.env.OIDC_REQUIRED_CLAIMS || 'sub')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+    oauthStorage,
+    redisUrl: process.env.REDIS_URL,
+    debugEnabled: oauthDebugEnabled,
+  };
+
+  if (cfg.oauthStorage === 'redis' && !cfg.redisUrl) {
+    throw new Error('OAUTH_STORAGE=redis requires REDIS_URL to be set.');
+  }
+
+  return cfg;
+};

--- a/src/mcp_server/bin.ts
+++ b/src/mcp_server/bin.ts
@@ -7,16 +7,26 @@
  */
 import { McpServer } from './server';
 
-const serverType = process.argv[2] || 'stdio';
+async function main() {
+  const serverType = process.argv[2] || 'stdio';
+  const server = new McpServer();
 
-const server = new McpServer();
+  if (serverType === 'stdio') {
+    await server.start();
+    return;
+  }
 
-if (serverType === 'stdio') {
-  server.start();
-} else if (serverType === 'http') {
-  const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
-  server.startHttp(port);
-} else {
+  if (serverType === 'http') {
+    const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+    await server.startHttp(port);
+    return;
+  }
+
   console.error(`Unknown server type: ${serverType}`);
-  process.exit(1);
+  process.exitCode = 1;
 }
+
+void main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/mcp_server/tools/symbol_analysis.ts
+++ b/src/mcp_server/tools/symbol_analysis.ts
@@ -2,12 +2,12 @@ import { z } from 'zod';
 import { fromKueryExpression, toElasticsearchQuery } from '../../../libs/es-query';
 import {
   client,
+  elasticsearchConfig,
   formatIndexNotFoundError,
   getChunksById,
   getLocationsIndexName,
   isIndexNotFoundError,
 } from '../../utils/elasticsearch';
-import { elasticsearchConfig } from '../../config';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types';
 
 /**

--- a/src/mcp_server/tools/whoami.md
+++ b/src/mcp_server/tools/whoami.md
@@ -1,0 +1,6 @@
+Returns the authenticated caller identity as seen by the server.
+
+Only available when `OIDC_AUTH_ENABLED=true`.
+
+This tool does **not** return tokens. It only returns derived identity/scope and the remaining TTL of the access token.
+

--- a/src/mcp_server/tools/whoami.ts
+++ b/src/mcp_server/tools/whoami.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types';
+
+import { getAuthClaims } from '../../auth/request_context';
+
+export const whoamiSchema = z.object({});
+
+export async function whoami(): Promise<CallToolResult> {
+  const claims = getAuthClaims();
+  if (!claims) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              authenticated: false,
+              reason: 'No HTTP auth context available (likely stdio transport or auth disabled).',
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const exp = typeof claims.exp === 'number' ? claims.exp : undefined;
+  const iat = typeof claims.iat === 'number' ? claims.iat : undefined;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            authenticated: true,
+            subject: claims.sub,
+            scope: claims.scope,
+            issuer: claims.iss,
+            audience: claims.aud,
+            iat,
+            exp,
+            expires_in_seconds: exp ? Math.max(0, exp - now) : null,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,13 @@
+import type { AccessTokenClaims } from '../auth/tokens';
+
+declare global {
+  namespace Express {
+    interface Request {
+      mcpAuth?: {
+        claims: AccessTokenClaims;
+      };
+    }
+  }
+}
+
+export {};

--- a/tests/auth/bearer_middleware.test.ts
+++ b/tests/auth/bearer_middleware.test.ts
@@ -1,0 +1,98 @@
+import express from 'express';
+
+import type { OAuthConfig } from '../../src/config';
+import { bearerAuth } from '../../src/auth/middleware';
+import { withHttpServer } from './test_server';
+
+jest.mock('../../src/auth/tokens', () => {
+  const verifyAccessToken = async (opts: { token: string }) => {
+    if (opts.token === 'bad') throw new Error('bad token');
+    if (opts.token === 'missing-email')
+      return { sub: 'user-1', scope: 'mcp:read', iss: 'http://mcp.test', aud: 'http://mcp.test' };
+    return {
+      sub: 'user-1',
+      email: 'user@example.com',
+      scope: 'mcp:read',
+      iss: 'http://mcp.test',
+      aud: 'http://mcp.test',
+    };
+  };
+  return { verifyAccessToken };
+});
+
+const makeCfg = (): OAuthConfig => ({
+  oauthServerUrl: 'http://mcp.test',
+  jwtSigningSecret: 'test-signing-secret',
+  oidcIssuer: 'https://issuer.example',
+  oidcClientId: 'client',
+  oidcClientSecret: 'secret',
+  oidcCookieSecret: 'cookie-secret',
+  oidcRequiredClaims: ['sub', 'email'],
+  oauthStorage: 'memory',
+  debugEnabled: false,
+});
+
+describe('bearerAuth middleware', () => {
+  test('returns 401 with WWW-Authenticate resource_metadata when missing token', async () => {
+    const cfg = makeCfg();
+    const app = express();
+    app.post('/mcp', bearerAuth(cfg), (_req, res) => res.status(200).send('ok'));
+
+    const srv = await withHttpServer(app);
+    try {
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(401);
+      const h = res.headers.get('www-authenticate') || '';
+      expect(h).toContain('Bearer');
+      expect(h).toContain('resource_metadata=');
+      expect(h).toContain(`${cfg.oauthServerUrl}/.well-known/oauth-protected-resource`);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  test('returns 401 invalid_token for bad token', async () => {
+    const cfg = makeCfg();
+    const app = express();
+    app.post('/mcp', bearerAuth(cfg), (_req, res) => res.status(200).send('ok'));
+
+    const srv = await withHttpServer(app);
+    try {
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer bad',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(401);
+      const h = res.headers.get('www-authenticate') || '';
+      expect(h).toContain('invalid_token');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  test('returns 403 when required claims missing', async () => {
+    const cfg = makeCfg();
+    const app = express();
+    app.post('/mcp', bearerAuth(cfg), (_req, res) => res.status(200).send('ok'));
+
+    const srv = await withHttpServer(app);
+    try {
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer missing-email', 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(403);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/auth/oauth_routes.test.ts
+++ b/tests/auth/oauth_routes.test.ts
@@ -1,0 +1,249 @@
+import express from 'express';
+
+import type { OAuthConfig } from '../../src/config';
+import { MemoryOAuthStorage } from '../../src/auth/storage/memory';
+import { hashRefreshToken } from '../../src/auth/token_utils';
+import { sha256Base64url } from '../../src/auth/crypto';
+import { withHttpServer } from './test_server';
+
+jest.mock('../../src/auth/tokens', () => {
+  const signAccessToken = async (opts: {
+    issuer: string;
+    audience: string;
+    subject: string;
+    scope: string;
+    extraClaims?: Record<string, unknown>;
+  }) => {
+    const payload = {
+      iss: opts.issuer,
+      aud: opts.audience,
+      sub: opts.subject,
+      scope: opts.scope,
+      iat: 1,
+      exp: 999999999,
+      ...(opts.extraClaims ?? {}),
+    };
+    return `fake.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.sig`;
+  };
+
+  const verifyAccessToken = async (opts: { token: string }) => {
+    const parts = opts.token.split('.');
+    if (parts.length < 2) throw new Error('bad token');
+    const payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf8')) as Record<string, unknown>;
+    return payload;
+  };
+
+  return { signAccessToken, verifyAccessToken };
+});
+
+const jsonObject = async (res: Response): Promise<Record<string, unknown>> => {
+  const j: unknown = await res.json();
+  if (!j || typeof j !== 'object' || Array.isArray(j)) {
+    throw new Error('Expected JSON object');
+  }
+  return j as Record<string, unknown>;
+};
+
+const makeCfg = (): OAuthConfig => ({
+  oauthServerUrl: 'http://mcp.test',
+  jwtSigningSecret: 'test-signing-secret',
+  oidcIssuer: 'https://issuer.example',
+  oidcClientId: 'client',
+  oidcClientSecret: 'secret',
+  oidcCookieSecret: 'cookie-secret',
+  oidcRequiredClaims: ['sub', 'email'],
+  oauthStorage: 'memory',
+  debugEnabled: false,
+});
+
+const makeApp = async (cfg: OAuthConfig, storage: MemoryOAuthStorage) => {
+  // Import after jest.mock so routes pick up mocked token functions.
+  const { registerDcrRoutes } = await import('../../src/auth/routes/register');
+  const { registerTokenRoutes } = await import('../../src/auth/routes/token');
+  const { registerWellKnownRoutes } = await import('../../src/auth/routes/well_known');
+
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  const router = express.Router();
+  registerWellKnownRoutes(router, cfg);
+  registerDcrRoutes(router, cfg, storage);
+  registerTokenRoutes(router, cfg, storage);
+  app.use(router);
+
+  return app;
+};
+
+describe('oauth routes (well-known, DCR, token)', () => {
+  test('well-known endpoints respond with CORS and metadata', async () => {
+    const cfg = makeCfg();
+    const storage = new MemoryOAuthStorage();
+    const app = await makeApp(cfg, storage);
+
+    const srv = await withHttpServer(app);
+    try {
+      const prm = await fetch(`${srv.baseUrl}/.well-known/oauth-protected-resource`);
+      expect(prm.status).toBe(200);
+      expect(prm.headers.get('access-control-allow-origin')).toBe('*');
+      const prmJson = await jsonObject(prm);
+      expect(prmJson.authorization_servers).toEqual(expect.arrayContaining([cfg.oauthServerUrl]));
+      expect(prmJson.scopes_supported).toEqual(expect.arrayContaining(['mcp:read']));
+
+      const as = await fetch(`${srv.baseUrl}/.well-known/oauth-authorization-server`);
+      expect(as.status).toBe(200);
+      expect(as.headers.get('access-control-allow-origin')).toBe('*');
+      const asJson = await jsonObject(as);
+      expect(asJson.issuer).toBe(cfg.oauthServerUrl);
+      expect(asJson.registration_endpoint).toBe(`${cfg.oauthServerUrl}/oauth/register`);
+      expect(asJson.code_challenge_methods_supported).toEqual(expect.arrayContaining(['S256']));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  test('DCR accepts cursor:// redirect URIs', async () => {
+    const cfg = makeCfg();
+    const storage = new MemoryOAuthStorage();
+    const app = await makeApp(cfg, storage);
+    const srv = await withHttpServer(app);
+
+    try {
+      const res = await fetch(`${srv.baseUrl}/oauth/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'Cursor',
+          redirect_uris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'none',
+          scope: 'mcp:read',
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const json = await jsonObject(res);
+      expect(typeof json.client_id).toBe('string');
+      expect(json.token_endpoint_auth_method).toBe('none');
+      expect(json.redirect_uris).toEqual(expect.arrayContaining(['cursor://anysphere.cursor-mcp/oauth/callback']));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  test('DCR rejects non-https/non-localhost/non-cursor redirect URIs', async () => {
+    const cfg = makeCfg();
+    const storage = new MemoryOAuthStorage();
+    const app = await makeApp(cfg, storage);
+    const srv = await withHttpServer(app);
+
+    try {
+      const res = await fetch(`${srv.baseUrl}/oauth/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'Bad',
+          redirect_uris: ['ftp://example.com/callback'],
+          token_endpoint_auth_method: 'none',
+        }),
+      });
+      expect(res.status).toBe(400);
+      const json = await jsonObject(res);
+      expect(json.error).toBe('invalid_redirect_uri');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  test('token endpoint exchanges auth code and rotates refresh token', async () => {
+    const cfg = makeCfg();
+    const storage = new MemoryOAuthStorage();
+    const app = await makeApp(cfg, storage);
+    const srv = await withHttpServer(app);
+
+    try {
+      const clientId = 'test-client';
+      await storage.createClient({
+        clientId,
+        redirectUris: ['http://localhost/callback'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+        responseTypes: ['code'],
+        tokenEndpointAuthMethod: 'none',
+        createdAtMs: Date.now(),
+      });
+
+      const codeVerifier = 'verifier-123';
+      const codeChallenge = sha256Base64url(codeVerifier);
+      const code = 'code-abc';
+      await storage.putAuthCode({
+        code,
+        clientId,
+        redirectUri: 'http://localhost/callback',
+        codeChallenge,
+        codeChallengeMethod: 'S256',
+        scope: 'mcp:read',
+        userClaims: { sub: 'user-1', email: 'user@example.com' },
+        expiresAtMs: Date.now() + 60_000,
+      });
+
+      const tokenRes = await fetch(`${srv.baseUrl}/oauth/token`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'authorization_code',
+          client_id: clientId,
+          code,
+          redirect_uri: 'http://localhost/callback',
+          code_verifier: codeVerifier,
+        }),
+      });
+      expect(tokenRes.status).toBe(200);
+      const tokenJson = await jsonObject(tokenRes);
+      expect(typeof tokenJson.access_token).toBe('string');
+      expect(typeof tokenJson.refresh_token).toBe('string');
+
+      const token = tokenJson.access_token as string;
+      const payload = JSON.parse(Buffer.from(token.split('.')[1]!, 'base64url').toString('utf8')) as Record<
+        string,
+        unknown
+      >;
+      expect(payload.sub).toBe('user-1');
+      expect(payload.email).toBe('user@example.com');
+
+      const oldRefresh = tokenJson.refresh_token as string;
+      const oldHash = hashRefreshToken(cfg.jwtSigningSecret, oldRefresh);
+      expect(await storage.getRefreshTokenByHash(oldHash)).not.toBeNull();
+
+      const refreshRes = await fetch(`${srv.baseUrl}/oauth/token`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          client_id: clientId,
+          refresh_token: oldRefresh,
+        }),
+      });
+      expect(refreshRes.status).toBe(200);
+      const refreshJson = await jsonObject(refreshRes);
+      expect(typeof refreshJson.refresh_token).toBe('string');
+      expect(refreshJson.refresh_token).not.toBe(oldRefresh);
+
+      // old refresh token should be invalid after rotation
+      const reuseRes = await fetch(`${srv.baseUrl}/oauth/token`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          client_id: clientId,
+          refresh_token: oldRefresh,
+        }),
+      });
+      expect(reuseRes.status).toBe(400);
+      const reuseJson = await jsonObject(reuseRes);
+      expect(reuseJson.error).toBe('invalid_grant');
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/auth/storage.test.ts
+++ b/tests/auth/storage.test.ts
@@ -1,0 +1,38 @@
+import Redis from 'ioredis';
+
+import { MemoryOAuthStorage } from '../../src/auth/storage/memory';
+import { RedisOAuthStorage } from '../../src/auth/storage/redis';
+
+jest.mock('ioredis');
+
+describe('storage', () => {
+  test('MemoryOAuthStorage lock prevents concurrent acquisition', async () => {
+    const s = new MemoryOAuthStorage();
+    const t1 = await s.acquireLock('k', 1);
+    expect(typeof t1).toBe('string');
+    const t2 = await s.acquireLock('k', 1);
+    expect(t2).toBeNull();
+    await s.releaseLock('k', t1!);
+    const t3 = await s.acquireLock('k', 1);
+    expect(typeof t3).toBe('string');
+  });
+
+  test('RedisOAuthStorage uses SET EX NX for locks', async () => {
+    const setMock = jest.fn().mockResolvedValue('OK');
+    const evalMock = jest.fn().mockResolvedValue(1);
+    (Redis as unknown as jest.Mock).mockImplementation(() => ({
+      set: setMock,
+      eval: evalMock,
+      get: jest.fn(),
+      del: jest.fn(),
+    }));
+
+    const s = new RedisOAuthStorage('redis://example');
+    const token = await s.acquireLock('lk', 5);
+    expect(typeof token).toBe('string');
+    expect(setMock).toHaveBeenCalledWith('lk', expect.any(String), 'EX', 5, 'NX');
+
+    await s.releaseLock('lk', token!);
+    expect(evalMock).toHaveBeenCalled();
+  });
+});

--- a/tests/auth/test_server.ts
+++ b/tests/auth/test_server.ts
@@ -1,0 +1,22 @@
+import http from 'http';
+
+export async function withHttpServer(handler: (req: http.IncomingMessage, res: http.ServerResponse) => void) {
+  const server = http.createServer(handler);
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+    server.on('error', reject);
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('Unexpected server address');
+
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    baseUrl,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}


### PR DESCRIPTION
## Summary
This PR adds **optional OAuth 2.0 authentication** (Authorization Code + PKCE) for the **HTTP transport**. When enabled, the server protects `POST /mcp` with a Bearer access token, and exposes the discovery + OAuth endpoints needed by MCP clients (e.g. Cursor) to obtain that token.

When disabled (`OIDC_AUTH_ENABLED=false`), behavior is unchanged (no auth enforced on `/mcp`).

## What’s included
- **Protected Resource Metadata (RFC 9728)**
  - `GET /.well-known/oauth-protected-resource`
  - `GET /.well-known/oauth-protected-resource/mcp`
- **Authorization Server metadata**
  - `GET /.well-known/oauth-authorization-server`
- **Dynamic Client Registration (DCR)**
  - `POST /oauth/register` (public clients only; `token_endpoint_auth_method=none`)
  - Redirect URIs restricted to **https**, **localhost**, or **`cursor://...`**
- **OAuth Authorization + Token endpoints**
  - `GET /oauth/authorize` (initiates upstream OIDC login + renders consent)
  - `POST /oauth/token` (exchanges code / refresh token)
  - Token responses set **`Cache-Control: no-store`** and **`Pragma: no-cache`** (RFC 6749)
- **Bearer middleware for `/mcp`**
  - Validates JWT access tokens minted by this server (`HS256` via `JWT_SIGNING_SECRET`)
  - Emits `WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/mcp"` so clients can discover auth
- **Storage backends**
  - In-memory for dev, Redis for production (refresh tokens, auth codes, user sessions)
  - `docker-compose.yml` added for local Redis
- **Auth-aware tool**
  - `whoami` tool is only registered when OAuth is enabled.

## High-level flow
1. Client hits `/mcp` without a token → gets `401` with `WWW-Authenticate` pointing at PRM.
2. Client discovers metadata via `/.well-known/oauth-protected-resource/mcp` and `/.well-known/oauth-authorization-server`.
3. Client registers via `POST /oauth/register` (or uses an existing `client_id`).
4. Client runs **Auth Code + PKCE** via `GET /oauth/authorize`.
5. Server delegates **user login** to the configured upstream **OIDC provider** (`OIDC_ISSUER`).
6. User approves consent page → server issues an **authorization code**.
7. Client exchanges code at `POST /oauth/token` → receives **access token (JWT)** + **refresh token**.
8. Client calls `POST /mcp` with `Authorization: Bearer <token>`.

## Configuration
See `.env.example` for the full list. Key settings:
- `OIDC_AUTH_ENABLED`: enable/disable OAuth protection
- `OAUTH_SERVER_URL`: public base URL (also used as issuer/audience for minted access tokens)
- `JWT_SIGNING_SECRET`: HS256 signing secret (must be stable across instances)
- `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`: upstream OIDC provider
- `OIDC_COOKIE_SECRET`: signs/encrypts state + cookies
- `OIDC_REQUIRED_CLAIMS`: required claims to allow `/mcp` access (default: `sub`)
- `OAUTH_STORAGE` + `REDIS_URL`: storage backend
- `OAUTH_DEBUG_ENABLED`: optional debug helpers

## Standards / compliance notes
- **RFC 6749**: token responses include `Cache-Control: no-store` and `Pragma: no-cache`.
- **RFC 9728**: base and `/mcp` PRM endpoints return a `resource` value matching the fetched URL.

## Test plan
- Automated: `npm test`
- Manual smoke:
  - Start Redis (optional): `docker compose up redis`
  - Set env vars (see `.env.example`)
  - Run HTTP server: `npm run mcp-server:http`
  - Verify discovery endpoints return JSON
  - Perform OAuth login in an MCP client and confirm `/mcp` returns `200` with a valid Bearer token.

## Follow-ups / ops considerations
- For production behind a load balancer, use **Redis storage** and stable secrets (`JWT_SIGNING_SECRET`, `OIDC_COOKIE_SECRET`).
- Ensure `OAUTH_SERVER_URL` is the externally reachable URL (affects discovery + token validation).